### PR TITLE
add reset option to wallet tool

### DIFF
--- a/common.py
+++ b/common.py
@@ -32,6 +32,13 @@ def get_addr_vbyte():
 	else:
 		return 0x00
 
+def get_signed_tx(wallet,ins,outs):
+	tx = btc.mktx(ins, outs)
+	for index, utxo in enumerate(ins):
+		addr = wallet.unspent[utxo['output']]['address']
+		tx = btc.sign(tx, index, wallet.get_key_from_addr(addr))
+	return tx
+
 class Wallet(object):
 	def __init__(self, seed, max_mix_depth=2):
 		self.max_mix_depth = max_mix_depth

--- a/common.py
+++ b/common.py
@@ -32,7 +32,7 @@ def get_addr_vbyte():
 	else:
 		return 0x00
 
-def get_signed_tx(wallet,ins,outs):
+def get_signed_tx(wallet, ins, outs):
 	tx = btc.mktx(ins, outs)
 	for index, utxo in enumerate(ins):
 		addr = wallet.unspent[utxo['output']]['address']

--- a/irclib.py
+++ b/irclib.py
@@ -83,6 +83,10 @@ class IRCClient(object):
 		self.cp_pubkeys[nick]=None
 		self.enc_boxes[nick]=None	
 	
+	def end_all_encryption(self):
+		for k,v in self.encrypting.iteritems():
+			if v: self.end_encryption(k)
+			
 	def encrypt_encode(self,msg,nick):
 		if not (nick in self.encrypting.keys()) or not (nick in self.enc_boxes.keys()):
 			raise Exception("Encryption is not switched on.")

--- a/maker.py
+++ b/maker.py
@@ -94,6 +94,8 @@ class CoinJoinOrder(object):
 				sigline = command_prefix + 'sig ' + sig
 		if len(sigline) > 0:
 			self.maker.privmsg(nick, sigline)
+		#once signature is sent, close encrypted channel to this taker.
+		self.maker.end_encryption(nick)
 
 	def unconfirm_callback(self, balance):
 		removed_utxos = self.maker.wallet.remove_old_utxos(self.tx)
@@ -193,7 +195,7 @@ class Maker(irclib.IRCClient):
 						btc_sig = chunks[2]
 					except (ValueError,IndexError) as e:
 						self.send_error(nick, str(e))
-					self.active_orders[nick].auth_counterparty(nick,i_utxo_pubkey,btc_sig)
+					self.active_orders[nick].auth_counterparty(nick, i_utxo_pubkey, btc_sig)
 					
 				if chunks[0] == 'fill':
 					if nick in self.active_orders and self.active_orders[nick] != None:

--- a/taker.py
+++ b/taker.py
@@ -240,6 +240,10 @@ class Taker(OrderbookWatch):
 					continue
 				self.cjtx.recv_txio(nick, utxo_list, cj_pub, change_addr)	
 			elif chunks[0] == 'sig':
+				#whether the signature is correct or not,
+				#we treat this as the last message for this tx from
+				#this nick, and therefore switch off encryption
+				self.end_encryption(nick)
 				sig = chunks[1]
 				self.cjtx.add_signature(sig)
 
@@ -309,7 +313,7 @@ def main():
 	seed = sys.argv[1] #btc.sha256('your brainwallet goes here')
 	keyfile = sys.argv[2]
 	from socket import gethostname
-	nickname = 'taker-' + btc.sha256(gethostname())[:6]
+	nickname = 'taker-' + sys.argv[2][:3] + btc.sha256(gethostname())[:6]
 
 	print 'downloading wallet history'
 	wallet = Wallet(seed, max_mix_depth=5)

--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -19,7 +19,9 @@ parser = OptionParser(usage='usage: %prog [options] [seed] [method]',
 	description='Does useful little lasts involving your bip32 wallet. The'
 	+ ' method is one of the following: Display- shows all addresses and balances'
 	+ '. Combine- combines all utxos into one output for each mixing level. Used for'
-	+ ' testing and is detrimental to privacy.')
+	+ ' testing and is detrimental to privacy.'
+        + ' reset - send all utxos back to first receiving address at zeroth mixing level.'
+        + ' Also only for testing and destroys privacy.')
 parser.add_option('-p', '--privkey', action='store_true', dest='showprivkey',
 	help='print private key along with address, default false')
 parser.add_option('-m', '--maxmixdepth', action='store', type='int', dest='maxmixdepth',

--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -79,7 +79,7 @@ elif method == 'combine':
 			if balance > 0:
 				destaddr = wallet.get_addr(m, forchange, wallet.index[m][forchange])
 				outs.append({'address': destaddr, 'value': balance})
-	print get_signed_tx(wallet,ins,outs)
+	print get_signed_tx(wallet, ins, outs)
 
 elif method == 'reset':
 	ins = []
@@ -90,6 +90,6 @@ elif method == 'reset':
 		balance += addrvalue['value']
 	destaddr = wallet.get_addr(0,0,0)
 	outs.append({'address': destaddr, 'value': balance})	
-	print get_signed_tx(wallet,ins,outs)
+	print get_signed_tx(wallet, ins, outs)
 	
 	

--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -1,6 +1,6 @@
 
 import bitcoin as btc
-from common import Wallet
+from common import Wallet, get_signed_tx
 
 import sys
 from optparse import OptionParser
@@ -61,6 +61,7 @@ if method == 'display':
 				used = ('used' if k < wallet.index[m][forchange] else ' new')
 				print '  m/0/%d/%d/%02d %s %s %.8fbtc' % (m, forchange, k, addr, used, balance/1e8)
 		print 'for mixdepth=%d balance=%.8fbtc' % (m, balance_depth/1e8)
+		
 elif method == 'combine':
 	ins = []
 	outs = []
@@ -78,8 +79,17 @@ elif method == 'combine':
 			if balance > 0:
 				destaddr = wallet.get_addr(m, forchange, wallet.index[m][forchange])
 				outs.append({'address': destaddr, 'value': balance})
-	tx = btc.mktx(ins, outs)
-	for index, utxo in enumerate(ins):
-		addr = wallet.unspent[utxo['output']]['address']
-		tx = btc.sign(tx, index, wallet.get_key_from_addr(addr))
-	print tx
+	print get_signed_tx(wallet,ins,outs)
+
+elif method == 'reset':
+	ins = []
+	outs = []
+	balance = 0
+	for utxo,addrvalue in wallet.unspent.iteritems():
+		ins.append({'output': utxo})
+		balance += addrvalue['value']
+	destaddr = wallet.get_addr(0,0,0)
+	outs.append({'address': destaddr, 'value': balance})	
+	print get_signed_tx(wallet,ins,outs)
+	
+	

--- a/yield-generator.py
+++ b/yield-generator.py
@@ -7,7 +7,6 @@ import time
 import pprint
 
 from socket import gethostname
-nickname = 'yigen-' + btc.sha256(gethostname())[:6]
 
 txfee = 1000
 cjfee = '0.01' # 1% fee
@@ -96,8 +95,8 @@ def main():
 	wallet = Wallet(seed, max_mix_depth = mix_levels)
 	wallet.download_wallet_history()
 	wallet.find_unspent_addresses()
-	
-	keyfile = 'keyfile-' + str(seed) + '.txt'
+	keyfile = sys.argv[2]
+	nickname = 'yigen-' + sys.argv[2][:3] + btc.sha256(gethostname())[:6]
 	maker = YieldGenerator(wallet, keyfile)
 	print 'connecting to irc'
 	maker.run(HOST, PORT, nickname, CHANNEL)

--- a/yield-generator.py
+++ b/yield-generator.py
@@ -64,7 +64,6 @@ class YieldGenerator(Maker):
 				break
 			mixdepth = (mixdepth - 1) % self.wallet.max_mix_depth
 		#mixdepth is the chosen depth we'll be spending from
-
 		mix_utxo_list = self.wallet.get_mix_utxo_list()
 		unspent = [{'utxo': utxo, 'value': self.wallet.unspent[utxo]['value']}
 			for utxo in mix_utxo_list[mixdepth]]
@@ -75,15 +74,15 @@ class YieldGenerator(Maker):
 
 	def on_tx_unconfirmed(self, cjorder, balance, removed_utxos):
 		#if the balance of the highest-balance mixing depth change then reannounce it
-		oldorder = self.orderlist[0]
+		oldorder = self.orderlist[0] if len(self.orderlist) > 0 else None	
 		neworders = self.create_my_orders()
 		if len(neworders) == 0:
 			return ([0], []) #cancel old order
-		elif oldorder['maxsize'] == neworders[0]['maxsize']:
-			return ([], []) #change nothing
-		else:
-			#announce new order, replacing the old order
-			return ([], [neworders[0]])
+		if oldorder: #oldorder may not exist when this is called from on_tx_confirmed
+			if oldorder['maxsize'] == neworders[0]['maxsize']:
+				return ([], []) #change nothing
+		#announce new order, replacing the old order
+		return ([], [neworders[0]])
 
 	def on_tx_confirmed(self, cjorder, confirmations, txid, balance, added_utxos):
 		return self.on_tx_unconfirmed(None, None, None)


### PR DESCRIPTION
An option to put all coins back to a single address. Perhaps useful if you want to re-start testing some aspect (although the "used" flags on addresses won't change of course), or to send coins back to the faucet. Debatable I guess, but since it's only an option, I suppose it doesn't hurt.