### PR TITLE
complete authentication by checking btc pubkey used is valid, also optim...

### DIFF
--- a/common.py
+++ b/common.py
@@ -60,7 +60,7 @@ def get_addr_from_utxo(txhash, index):
 	'''return the bitcoin address of the outpoint at 
 	the specified index for the transaction with specified hash.
 	Return None if no such index existed for that transaction.'''
-	data = get_blockchain_data('txinfo',csv_params=[txhash])
+	data = get_blockchain_data('txinfo', csv_params=[txhash])
 	for a in data['vouts']:
 		if a['n']==index:
 			return a['address']
@@ -292,7 +292,7 @@ def add_addr_notify(address, unconfirmfun, confirmfun, unconfirmtimeout=5,
 						unconfirmtimeoutfun()
 					debug('checking for unconfirmed tx timed out')
 					return
-				data = get_blockchain_data('addrbalance',csv_params=[self.address],
+				data = get_blockchain_data('addrbalance', csv_params=[self.address],
 				                           query_params=['confirmations=0'])
 				if data['balance'] > 0:
 					break
@@ -305,7 +305,7 @@ def add_addr_notify(address, unconfirmfun, confirmfun, unconfirmtimeout=5,
 						confirmtimeoutfun()
 					debug('checking for confirmed tx timed out')
 					return
-				data = get_blockchain_data('addrtx',csv_params=[self.address],
+				data = get_blockchain_data('addrtx', csv_params=[self.address],
 				                           query_params=['confirmations=0'])
 				if data['nb_txs'] == 0:
 					continue

--- a/common.py
+++ b/common.py
@@ -56,7 +56,31 @@ def debug_dump_object(obj, skip_fields=[]):
 		else:
 			print v
 
-
+def get_addr_from_utxo(txhash, index):
+	'''return the bitcoin address of the outpoint at 
+	the specified index for the transaction with specified hash.
+	Return None if no such index existed for that transaction.'''
+	data = get_blockchain_data('txinfo',csv_params=[txhash])
+	for a in data['vouts']:
+		if a['n']==index:
+			return a['address']
+	return None
+	
+def get_blockchain_data(body, source='blockr', csv_params=[],
+                        query_params=[], network='test', output_key='data'):
+	'''A first step towards encapsulating blockchain queries.'''
+	if source != 'blockr': raise Exception ("source not yet implemented")
+	stem = 'http://btc.blockr.io/api/v1/'
+	if network=='test': stem = stem[:7]+'t'+stem[7:]
+	elif network != 'main': raise Exception("unrecognised bitcoin network type")
+	bodies = {'addrtx':'address/txs/','txinfo':'tx/info/','addrunspent':'address/unspent/',
+	          'addrbalance':'address/balance/'}
+	url = stem + bodies[body] + ','.join(csv_params) 
+	if query_params:
+		url += '?'+','.join(query_params)
+	res = btc.make_request(url)
+	return json.loads(res)[output_key]
+	
 class Wallet(object):
 	def __init__(self, seed, max_mix_depth=2):
 		self.max_mix_depth = max_mix_depth
@@ -179,12 +203,7 @@ class Wallet(object):
 
 					#TODO send a pull request to pybitcointools
 					# because this surely should be possible with a function from it
-					if get_network() == 'testnet':
-						blockr_url = 'http://tbtc.blockr.io/api/v1/address/txs/'
-					elif network == 'btc':
-						blockr_url = 'http://btc.blockr.io/api/v1/address/txs/'
-					res = btc.make_request(blockr_url+','.join(addrs))
-					data = json.loads(res)['data']
+					data = get_blockchain_data('addrtx', csv_params=addrs)
 					for dat in data:
 						if dat['nb_txs'] != 0:
 							last_used_addr = dat['address']
@@ -227,13 +246,8 @@ class Wallet(object):
 			#TODO send a pull request to pybitcointools 
 			# unspent() doesnt tell you which address, you get a bunch of utxos
 			# but dont know which privkey to sign with
-			if get_network() == 'testnet':
-				blockr_url = 'http://tbtc.blockr.io/api/v1/address/unspent/'
-			elif network == 'btc':
-				blockr_url = 'http://btc.blockr.io/api/v1/address/unspent/'
-			blockr_url += ','.join(req) + '?unconfirmed=1'
-			res = btc.make_request(blockr_url)
-			data = json.loads(res)['data']
+			data = get_blockchain_data('addrunspent', csv_params=req, 
+			                          query_params=['unconfirmed=1'])
 			if 'unspent' in data:
 				data = [data]
 			for dat in data:
@@ -278,12 +292,8 @@ def add_addr_notify(address, unconfirmfun, confirmfun, unconfirmtimeout=5,
 						unconfirmtimeoutfun()
 					debug('checking for unconfirmed tx timed out')
 					return
-				if get_network() == 'testnet':
-					blockr_url = 'http://tbtc.blockr.io/api/v1/address/balance/'
-				else:
-					blockr_url = 'http://btc.blockr.io/api/v1/address/balance/'
-				res = btc.make_request(blockr_url + self.address + '?confirmations=0')
-				data = json.loads(res)['data']
+				data = get_blockchain_data('addrbalance',csv_params=[self.address],
+				                           query_params=['confirmations=0'])
 				if data['balance'] > 0:
 					break
 			self.unconfirmfun(data['balance']*1e8)
@@ -295,12 +305,8 @@ def add_addr_notify(address, unconfirmfun, confirmfun, unconfirmtimeout=5,
 						confirmtimeoutfun()
 					debug('checking for confirmed tx timed out')
 					return
-				if get_network() == 'testnet':
-					blockr_url = 'http://tbtc.blockr.io/api/v1/address/txs/'
-				else:
-					blockr_url = 'http://btc.blockr.io/api/v1/address/txs/'
-				res = btc.make_request(blockr_url + self.address + '?confirmations=0')
-				data = json.loads(res)['data']
+				data = get_blockchain_data('addrtx',csv_params=[self.address],
+				                           query_params=['confirmations=0'])
 				if data['nb_txs'] == 0:
 					continue
 				if data['txs'][0]['confirmations'] >= 1: #confirmation threshold

--- a/enc_wrapper.py
+++ b/enc_wrapper.py
@@ -43,7 +43,7 @@ def as_init_encryption(kp, c_pk):
     pubkey c_pk, create a Box 
     ready for encryption/decryption.
     '''
-    return libnacl.public.Box(kp.sk,c_pk)
+    return libnacl.public.Box(kp.sk, c_pk)
 '''
 After initialisation, it's possible
 to use the box object returned from
@@ -88,13 +88,13 @@ if __name__ == "__main__":
     bob_kp = init_keypair()
     
     #this is the DH key exchange part
-    bob_otwpk = get_pubkey(bob_kp,True)
-    alice_otwpk = get_pubkey(alice_kp,True)
+    bob_otwpk = get_pubkey(bob_kp, True)
+    alice_otwpk = get_pubkey(alice_kp, True)
     
     bob_pk = init_pubkey(bob_otwpk)
-    alice_box = as_init_encryption(alice_kp,bob_pk)
+    alice_box = as_init_encryption(alice_kp, bob_pk)
     alice_pk = init_pubkey(alice_otwpk)
-    bob_box = as_init_encryption(bob_kp,alice_pk)
+    bob_box = as_init_encryption(bob_kp, alice_pk)
     
     #now Alice and Bob can use their 'box'
     #constructs (both of which utilise the same

--- a/encryption_protocol.txt
+++ b/encryption_protocol.txt
@@ -16,7 +16,7 @@ Encrypted
 
 TAK: !auth <input utxo pubkey> <btc sig of taker encryption pubkey using input utxo pubkey>
 (Maker verifies the btc sig; if not valid, connection is dropped - send REJECT message)
-MAK: !auth <utxo list> <coinjoin pubkey> <change address> <btc sig of maker encryption pubkey using coinjoin pubkey>
+MAK: !ioauth <utxo list> <coinjoin pubkey> <change address> <btc sig of maker encryption pubkey using coinjoin pubkey>
 (Taker verifies the btc sig; if not valid, as for previous)
 
 Because the !auth messages are under encryption, there is no privacy leak of bitcoin pubkeys or output addresses.
@@ -25,6 +25,7 @@ If both verifications pass, the remainder of the messages exchanged between the 
 
 Specifically, these message types will be encrypted:
 !auth
+!ioauth
 !tx
 !sig
 

--- a/irclib.py
+++ b/irclib.py
@@ -98,7 +98,7 @@ class IRCClient(object):
 		box = self.encrypting(cmd, nick, sending=True)
 		#encrypt before chunking
 		if box:
-			message = enc_wrapper.encrypt_encode(message,box)
+			message = enc_wrapper.encrypt_encode(message, box)
 		
 		if len(message) > 350:
 			message_chunks = chunks(message, 350)

--- a/maker.py
+++ b/maker.py
@@ -35,10 +35,10 @@ class CoinJoinOrder(object):
 		# orders to find out which addresses you use
 		self.maker.privmsg(nick, 'pubkey', self.kp.hex_pk())
 		
-	def auth_counterparty(self,nick,i_utxo_pubkey,btc_sig):
+	def auth_counterparty(self, nick, i_utxo_pubkey, btc_sig):
 		self.i_utxo_pubkey = i_utxo_pubkey
 		
-		if not btc.ecdsa_verify(self.taker_pk,btc_sig,self.i_utxo_pubkey):
+		if not btc.ecdsa_verify(self.taker_pk, btc_sig, self.i_utxo_pubkey):
 			print 'signature didnt match pubkey and message'
 			return False
 		#authorisation of taker passed 
@@ -47,7 +47,7 @@ class CoinJoinOrder(object):
 		#TODO the next 2 lines are a little inefficient.
 		btc_key = self.maker.wallet.get_key_from_addr(self.cj_addr)
 		btc_pub = btc.privtopub(btc_key)
-		btc_sig = btc.ecdsa_sign(self.kp.hex_pk(),btc_key)
+		btc_sig = btc.ecdsa_sign(self.kp.hex_pk(), btc_key)
 		authmsg = str(','.join(self.utxos)) + ' ' + \
 	                btc_pub + ' ' + self.change_addr + ' ' + btc_sig
 		self.maker.privmsg(nick, 'ioauth', authmsg)		
@@ -110,8 +110,8 @@ class CoinJoinOrder(object):
 		tx_utxo_set = set([ins['outpoint']['hash'] + ':' \
 		                   + str(ins['outpoint']['index']) for ins in txd['ins']])
 		#complete authentication: check the tx input uses the authing pubkey
-		if not btc.pubtoaddr(self.i_utxo_pubkey,get_addr_vbyte()) \
-		   in [get_addr_from_utxo(i['outpoint']['hash'],i['outpoint']['index']) \
+		if not btc.pubtoaddr(self.i_utxo_pubkey, get_addr_vbyte()) \
+		   in [get_addr_from_utxo(i['outpoint']['hash'], i['outpoint']['index']) \
 		   for i in txd['ins']]:
 		        return False, "authenticating bitcoin address is not contained"			
 		my_utxo_set = set(self.utxos)
@@ -165,7 +165,7 @@ class Maker(irclib.IRCClient):
 		orderline = ''
 		for order in orderlist:
 			elem_list = [str(order[k]) for k in order_keys]
-			self.privmsg(target,order['ordertype'],' '.join(elem_list))
+			self.privmsg(target, order['ordertype'],' '.join(elem_list))
 		
 	def send_error(self, nick, errmsg):
 		debug('error<%s> : %s' % (nick, errmsg))
@@ -209,7 +209,7 @@ class Maker(irclib.IRCClient):
 					try:
 						i_utxo_pubkey = chunks[1]
 						btc_sig = chunks[2]					
-					except (ValueError,IndexError) as e:
+					except (ValueError, IndexError) as e:
 						self.send_error(nick, str(e))
 					self.active_orders[nick].auth_counterparty(nick, i_utxo_pubkey, btc_sig)
 					
@@ -349,7 +349,7 @@ def main():
 	import sys
 	seed = sys.argv[1] #btc.sha256('dont use brainwallets except for holding testnet coins')
 
-	wallet = Wallet(seed,max_mix_depth=5)
+	wallet = Wallet(seed, max_mix_depth=5)
 	wallet.sync_wallet()
 
 	maker = Maker(wallet)

--- a/maker.py
+++ b/maker.py
@@ -36,14 +36,14 @@ class CoinJoinOrder(object):
 		self.maker.privmsg(nick, 'pubkey', self.kp.hex_pk())
 		
 	def auth_counterparty(self,nick,i_utxo_pubkey,btc_sig):
-		#TODO: add check that the pubkey's address is part of the order.
 		self.i_utxo_pubkey = i_utxo_pubkey
 		
 		if not btc.ecdsa_verify(self.taker_pk,btc_sig,self.i_utxo_pubkey):
 			print 'signature didnt match pubkey and message'
 			return False
-		#authorisation of taker passed
-		#send auth request to taker
+		#authorisation of taker passed 
+		#(but input utxo pubkey is checked in verify_unsigned_tx).
+		#Send auth request to taker
 		#TODO the next 2 lines are a little inefficient.
 		btc_key = self.maker.wallet.get_key_from_addr(self.cj_addr)
 		btc_pub = btc.privtopub(btc_key)
@@ -107,7 +107,13 @@ class CoinJoinOrder(object):
 		self.maker.modify_orders(to_cancel, to_announce)
 
 	def verify_unsigned_tx(self, txd):
-		tx_utxo_set = set([ins['outpoint']['hash'] + ':' + str(ins['outpoint']['index']) for ins in txd['ins']])
+		tx_utxo_set = set([ins['outpoint']['hash'] + ':' \
+		                   + str(ins['outpoint']['index']) for ins in txd['ins']])
+		#complete authentication: check the tx input uses the authing pubkey
+		if not btc.pubtoaddr(self.i_utxo_pubkey,get_addr_vbyte()) \
+		   in [get_addr_from_utxo(i['outpoint']['hash'],i['outpoint']['index']) \
+		   for i in txd['ins']]:
+		        return False, "authenticating bitcoin address is not contained"			
 		my_utxo_set = set(self.utxos)
 		wallet_utxos = set(self.maker.wallet.unspent)
 		if not tx_utxo_set.issuperset(my_utxo_set):

--- a/taker.py
+++ b/taker.py
@@ -42,7 +42,7 @@ class CoinJoinTX(object):
 	def start_encryption(self, nick, maker_pk):
 		if nick not in self.active_orders.keys():
 			raise Exception("Counterparty not part of this transaction.")
-		self.crypto_boxes[nick] = [maker_pk,enc_wrapper.as_init_encryption(\
+		self.crypto_boxes[nick] = [maker_pk, enc_wrapper.as_init_encryption(\
 		                        self.kp, enc_wrapper.init_pubkey(maker_pk))]
 		#send authorisation request
 		my_btc_priv = self.taker.wallet.get_key_from_addr(\
@@ -62,7 +62,7 @@ class CoinJoinTX(object):
 		return True
 	
 	def recv_txio(self, nick, utxo_list, cj_pub, change_addr):	
-		cj_addr = btc.pubtoaddr(cj_pub,get_addr_vbyte())
+		cj_addr = btc.pubtoaddr(cj_pub, get_addr_vbyte())
 		if nick not in self.nonrespondants:
 			debug('nick(' + nick + ') not in nonrespondants ' + str(self.nonrespondants))
 			return
@@ -291,7 +291,7 @@ class TestTaker(Taker):
 				print 'making cjtx'
 				self.cjtx = CoinJoinTX(self, int(amt), {cp: oid},
 			                utxos, self.wallet.get_receive_addr(mixing_depth=1),
-			                self.wallet.get_change_addr(mixing_depth=0), my_tx_fee,self.finish_callback)								
+			                self.wallet.get_change_addr(mixing_depth=0), my_tx_fee, self.finish_callback)								
 			elif chunks[0] == '%unspent':
 				from pprint import pprint
 				pprint(self.wallet.unspent)
@@ -304,7 +304,7 @@ class TestTaker(Taker):
 				print 'making cjtx'
 				self.cjtx = CoinJoinTX(self, int(amount), {counterparty: oid},
 					[my_utxo], self.wallet.get_receive_addr(mixing_depth=1),
-					self.wallet.get_change_addr(mixing_depth=0), my_tx_fee,self.finish_callback)
+					self.wallet.get_change_addr(mixing_depth=0), my_tx_fee, self.finish_callback)
 			elif chunks[0] == '%2fill':
 				#!2fill [amount] [utxo] [counterparty1] [oid1] [counterparty2] [oid2]
 				amount = int(chunks[1])
@@ -316,7 +316,7 @@ class TestTaker(Taker):
 				print 'creating cjtx'
 				self.cjtx = CoinJoinTX(self, amount, {cp1: oid1, cp2: oid2},
 					[my_utxo], self.wallet.get_receive_addr(mixing_depth=1),
-					self.wallet.get_change_addr(mixing_depth=0), my_tx_fee,self.finish_callback)
+					self.wallet.get_change_addr(mixing_depth=0), my_tx_fee, self.finish_callback)
 
 def main():
 	import sys

--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -105,7 +105,7 @@ elif method == 'reset':
 	ins = []
 	outs = []
 	balance = 0
-	for utxo,addrvalue in wallet.unspent.iteritems():
+	for utxo, addrvalue in wallet.unspent.iteritems():
 		ins.append({'output': utxo})
 		balance += addrvalue['value']
 	destaddr = wallet.get_addr(0,0,0)


### PR DESCRIPTION
...ise blockchain query code.

The main point here is that in the CoinJoinOrder code, when we verify_unsigned_tx, we check that at least one of the inputs to the transaction comes from the bitcoin pubkey that was used to sign the encryption pubkey for the counterparty (taker). This check was already implicit on the taker side, so no change needed (cj_pubkey).

Also encapsulated the queries to blockr.io in a function in common.py.

Let me know if anything else is needed or doesn't work.