### PR TITLE
Fix BitcoinCoreWallet's UTXO selection.

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -323,7 +323,7 @@ class BitcoinCoreWallet(AbstractWallet):
 		for u in unspent_list:
 			if not u['spendable']:
 				continue
-			if self.fromaccount and 'account' in u and u['account'] != self.fromaccount:
+			if self.fromaccount and (('account' not in u) or u['account'] != self.fromaccount):
 				continue
 			result[0][u['txid'] + ':' + str(u['vout'])] = {'address': u['address'],
 				'value': int(Decimal(str(u['amount'])) * Decimal('1e8'))}


### PR DESCRIPTION
The UTXO selection of BitcoinCoreWallet with fromaccount set did accept also UTXO's without an account.  This is in direct contradiction to the user's wish for a specific account.  With this patch, we really only accept UTXO's that have the specified account set explicitly.