### PR TITLE
fix DUST_THRESHOLD typo - Discuss Best Practices

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -10,7 +10,7 @@ import os, io, itertools
 
 JM_VERSION = 1
 nickname = ''
-DUST_THRESHOLD = 543
+DUST_THRESHOLD = 546
 bc_interface = None
 ordername_list = ["absorder", "relorder"]
 


### PR DESCRIPTION
[reduced dust threshold to 543, in line with electrum](https://github.com/chris-belcher/joinmarket/commit/652ee06612a750e60d75cec30b8e7160816b4e96)

At minimum, this should be [corrected to 546](https://github.com/bitcoin/bitcoin/blob/master/src/primitives/transaction.h#L146).  

I think maybe it should be a maker cfg option, default set to match core default (546), but I would propose increasing it to approx. 5500 satoshis for these reasons;

1) At today's prices, 546 satoshis is ~$0.0013 USD, and would only be $0.00546 if BTC went to $1000/BTC.  A dust limit of ~5500 would be about $0.01375 at current prices, and $0.055 at $1000/BTC.

2) I think the typical use cases for joinmarket won't involve a lot of these low value ($) transactions.

3) I wouldn't want my wallet cluttered with utxos holding ~546 satoshis, as this means even larger transaction sizes (kb) and potentially higher fees when I want to use those utxos in the future.

I am sure there are different opinions on this, and I'd like to hear them while I continue my thoughts and research on this.