### PR TITLE
Bootstrap styling fix and added total of MaxSize in ob-watcher.py table

### DIFF
--- a/ob-watcher.py
+++ b/ob-watcher.py
@@ -105,6 +105,7 @@ class OrderbookPageRequestHeader(SimpleHTTPServer.SimpleHTTPRequestHandler):
 
 	def create_orderbook_table(self, orderby, desc):
 		result = ''
+		totalMaxSize = 0.0
 		rows = self.taker.db.execute('SELECT * FROM orderbook;').fetchall()
 		if not rows:
 			return 0, result
@@ -127,7 +128,10 @@ class OrderbookPageRequestHeader(SimpleHTTPServer.SimpleHTTPRequestHandler):
 				 ('minsize', satoshi_to_unit), ('maxsize', satoshi_to_unit))
 			for key, displayer in order_keys_display:
 				result += '  <td>' + displayer(o[key], o) + '</td>\n'
+				if key == "maxsize":
+					totalMaxSize += float(displayer(o[key], o))
 			result += ' </tr>\n'
+		result += ' <tfoot><tr><td colspan="6" style="font-weight:bold;text-align:right;">Total</td> <td>' + str(totalMaxSize) + '</td></tr></tfoot>\n'
 		return len(rows), result
 
 	def get_counterparty_count(self):

--- a/orderbook.html
+++ b/orderbook.html
@@ -42,7 +42,7 @@
 	        </div>
 	        <div id="navbar" class="collapse navbar-collapse">
 	          <ul class="nav navbar-nav">
-	            <li class="active"><a href="/">Orders</a></li>
+	            <li><a href="/">Orders</a></li>
 	            <li><a href="/ordersize">Size Distribution</a></li>
 	            <li><a href="/depth">Depth</a></li>
 	            <li><a href="#">UTXOs - Coming Soon</a></li>


### PR DESCRIPTION
- Removed active class from navbar item so that it doesn't appear you're on the same page when you click the links in the navbar
- Added a total of the maxsize column in the `ob-watcher.py` code, and then added it to the table footer