### PR TITLE
coin unit choices

### DIFF
--- a/ob-watcher.py
+++ b/ob-watcher.py
@@ -11,6 +11,16 @@ from irc import IRCMessageChannel, random_nick
 from common import *
 import common
 
+#  BTC (1  BTC = 1.00000000 BTC) # bitcoin
+# mBTC (1 mBTC = 0.00100000 BTC) # millibitcoin
+# uBTC (1 uBTC = 0.00000100 BTC) # microbitcoin, aka 'bit'
+# Sats (1 Sats = 0.00000001 BTC) # Satoshis
+# Uncomment only one of these unit choices:
+UnitDisplayType = "BTC"
+#UnitDisplayType = "mBTC"
+#UnitDisplayType = "uBTC"
+#UnitDisplayType = "Satoshis"
+
 # ['counterparty', 'oid', 'ordertype', 'minsize', 'maxsize', 'txfee', 'cjfee']
 col = '  <th>{1}</th>\n' # .format(field,label)
 
@@ -92,7 +102,14 @@ def cjfee_display(cjfee, order):
 		return str(float(cjfee) * 100) + '%'
 
 def satoshi_to_unit(sat, order):
-	return str(Decimal(sat) / Decimal(1e8))
+        if UnitDisplayType == "BTC":
+                return "%.8f" % float(Decimal(sat) / Decimal(1e8))
+        if UnitDisplayType == "mBTC":
+                return "%.5f" % float(Decimal(sat) / Decimal(1e5))
+        if UnitDisplayType == "uBTC":
+                return "%.2f" % float(Decimal(sat) / Decimal(100))
+        if UnitDisplayType == "Satoshis":
+                return "%.f" % float(Decimal(sat) / Decimal(1))
 
 def order_str(s, order):
 	return str(s)

--- a/ob-watcher.py
+++ b/ob-watcher.py
@@ -16,10 +16,10 @@ import common
 # uBTC (1 uBTC = 0.00000100 BTC) # microbitcoin, aka 'bit'
 # Sats (1 Sats = 0.00000001 BTC) # Satoshis
 # Uncomment only one of these unit choices:
-UnitDisplayType = "BTC"
-#UnitDisplayType = "mBTC"
-#UnitDisplayType = "uBTC"
-#UnitDisplayType = "Satoshis"
+unit_display_type = "BTC"
+#unit_display_type = "mBTC"
+#unit_display_type = "uBTC"
+#unit_display_type = "Satoshis"
 
 # ['counterparty', 'oid', 'ordertype', 'minsize', 'maxsize', 'txfee', 'cjfee']
 col = '  <th>{1}</th>\n' # .format(field,label)
@@ -102,13 +102,13 @@ def cjfee_display(cjfee, order):
 		return str(float(cjfee) * 100) + '%'
 
 def satoshi_to_unit(sat, order):
-        if UnitDisplayType == "BTC":
+        if unit_display_type == "BTC":
                 return "%.8f" % float(Decimal(sat) / Decimal(1e8))
-        if UnitDisplayType == "mBTC":
+        if unit_display_type == "mBTC":
                 return "%.5f" % float(Decimal(sat) / Decimal(1e5))
-        if UnitDisplayType == "uBTC":
+        if unit_display_type == "uBTC":
                 return "%.2f" % float(Decimal(sat) / Decimal(100))
-        if UnitDisplayType == "Satoshis":
+        if unit_display_type == "Satoshis":
                 return "%.f" % float(Decimal(sat) / Decimal(1))
 
 def order_str(s, order):


### PR DESCRIPTION
for [114](https://github.com/chris-belcher/joinmarket/issues/114) - added [unit choices](https://github.com/chris-belcher/joinmarket/issues/114#issue-92050486) and cleaned BTC decimal precision displayed, did not include [bp or ppm for cjfee](https://github.com/chris-belcher/joinmarket/issues/114#issuecomment-118338157), but can easily add if there is demand