### PR TITLE
bug fix

### DIFF
--- a/lib/maker.py
+++ b/lib/maker.py
@@ -116,8 +116,7 @@ class CoinJoinOrder(object):
 		finally:
 			self.maker.wallet_unspent_lock.release()
 		debug('tx in a block')
-		to_cancel, to_announce = self.maker.on_tx_confirmed(self,
-			confirmations, txid)
+                to_cancel, to_announce = self.maker.on_tx_confirmed(self, cjorder, confirmations, txid)
 		self.maker.modify_orders(to_cancel, to_announce)
 
 	def verify_unsigned_tx(self, txd):


### PR DESCRIPTION
    ----------------------------------------
    Exception happened during processing of request from ('127.0.0.1', 36796)
    Traceback (most recent call last):
      File "/usr/lib/python2.7/SocketServer.py", line 295, in _handle_request_noblock
        self.process_request(request, client_address)
      File "/usr/lib/python2.7/SocketServer.py", line 321, in process_request
        self.finish_request(request, client_address)
      File "/usr/lib/python2.7/SocketServer.py", line 334, in finish_request
        self.RequestHandlerClass(request, client_address, self)
      File "/home/redacted/joinmarket/lib/blockchaininterface.py", line 277, in __init__
        SimpleHTTPServer.SimpleHTTPRequestHandler.__init__(self, request, client_address, base_server)
      File "/usr/lib/python2.7/SocketServer.py", line 649, in __init__
        self.handle()
      File "/usr/lib/python2.7/BaseHTTPServer.py", line 340, in handle
        self.handle_one_request()
      File "/usr/lib/python2.7/BaseHTTPServer.py", line 328, in handle_one_request
        method()
      File "/home/redacted/joinmarket/lib/blockchaininterface.py", line 311, in do_HEAD
        confirmfun(txd, txid, txdata['confirmations'])
      File "/home/redacted/joinmarket/lib/maker.py", line 120, in confirm_callback
        confirmations, txid)
    TypeError: on_tx_confirmed() takes exactly 5 arguments (4 given)
    ----------------------------------------