### PR TITLE
Display tx fee contribution when picking orders.

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -384,7 +384,7 @@ def pick_order(orders, n, feekey):
 	print("Considered orders:");
 	for o in orders:
 		i+=1
-		print("    "+str(i)+". "+str(o[0])+", CJ fee: "+str(o[2]))
+		print("    %2d. %20s, CJ fee: %6d, tx fee: %6d" % (i, o[0], o[2], o[3]))
 	pickedOrderIndex = -1
 	if i==0:
 		print("Only one possible pick, picking it.")
@@ -403,7 +403,7 @@ def pick_order(orders, n, feekey):
 
 def choose_order(db, cj_amount, n, chooseOrdersBy):
 	sqlorders = db.execute('SELECT * FROM orderbook;').fetchall()
-	orders = [(o['counterparty'], o['oid'],	calc_cj_fee(o['ordertype'], o['cjfee'], cj_amount))
+	orders = [(o['counterparty'], o['oid'],	calc_cj_fee(o['ordertype'], o['cjfee'], cj_amount), o['txfee'])
 		for o in sqlorders if cj_amount >= o['minsize'] and cj_amount <= o['maxsize']]
 	counterparties = set([o[0] for o in orders])
 	if n > len(counterparties):


### PR DESCRIPTION
In the 'pick orders' dialog, display the tx fee contribution in addition to the resulting CJ fee for each order.

I also changed the display formatting a bit, IMHO the new display is more readable as it is "tabular".  If this change is not desired, let me know and I'll revert it and just append the tx fee contribution at the end.