### PR TITLE
Implement JSON-RPC interface instead of CLI.

### DIFF
--- a/lib/blockchaininterface.py
+++ b/lib/blockchaininterface.py
@@ -1,5 +1,4 @@
 #from joinmarket import *
-import subprocess
 import unittest
 import json, threading, abc, pprint, time, random, sys, os, re
 import BaseHTTPServer, urllib
@@ -7,15 +6,22 @@ from decimal import Decimal
 import bitcoin as btc
 
 import common
+import jsonrpc
 
 def get_blockchain_interface_instance(config):
 	source = config.get("BLOCKCHAIN", "blockchain_source")
-	bitcoin_cli_cmd = config.get("BLOCKCHAIN", "bitcoin_cli_cmd").split(' ')
-	testnet = common.get_network()=='testnet'
+	rpc_host = config.get("BLOCKCHAIN", "rpc_host")
+	rpc_port = config.get("BLOCKCHAIN", "rpc_port")
+	rpc_user = config.get("BLOCKCHAIN", "rpc_user")
+	rpc_password = config.get("BLOCKCHAIN", "rpc_password")
+	network = common.get_network()
+	testnet = network=='testnet'
 	if source == 'json-rpc':
-		bc_interface = BitcoinCoreInterface(bitcoin_cli_cmd, testnet)
+		rpc = jsonrpc.JsonRpc(rpc_host, rpc_port, rpc_user, rpc_password)
+		bc_interface = BitcoinCoreInterface(rpc, network)
 	elif source == 'regtest':
-		bc_interface = RegtestBitcoinCoreInterface(bitcoin_cli_cmd)
+		rpc = jsonrpc.JsonRpc(rpc_host, rpc_port, rpc_user, rpc_password)
+		bc_interface = RegtestBitcoinCoreInterface(rpc)
 	elif source == 'blockr':
 		bc_interface = BlockrInterface(testnet)
 	else:
@@ -284,7 +290,7 @@ class NotifyRequestHeader(BaseHTTPServer.BaseHTTPRequestHandler):
 			if not re.match('^[0-9a-fA-F]*$', txid):
 				common.debug('not a txid')
 				return
-			tx = self.btcinterface.rpc(['getrawtransaction', txid]).strip()
+			tx = self.btcinterface.rpc('getrawtransaction', [txid])
 			if not re.match('^[0-9a-fA-F]*$', tx):
 				common.debug('not a txhex')
 				return
@@ -302,8 +308,8 @@ class NotifyRequestHeader(BaseHTTPServer.BaseHTTPRequestHandler):
 			else:
 				jsonstr = None #on rare occasions people spend their output without waiting for a confirm
 				for n in range(len(txd['outs'])):
-					jsonstr = self.btcinterface.rpc(['gettxout', txid, str(n), 'true'])
-					if jsonstr != '':
+					txout = self.btcinterface.rpc('gettxout', [txid, n, True])
+					if txout is not None:
 						break
 				assert jsonstr != ''
 				txdata = json.loads(jsonstr)
@@ -358,30 +364,33 @@ class BitcoinCoreNotifyThread(threading.Thread):
 #TODO must add the tx addresses as watchonly if case we ever broadcast a tx
 # with addresses not belonging to us
 class BitcoinCoreInterface(BlockchainInterface):
-	def __init__(self, bitcoin_cli_cmd, testnet = False):
+	def __init__(self, jsonRpc, network):
 		super(BitcoinCoreInterface, self).__init__()
-		self.command_params = bitcoin_cli_cmd
-		if testnet:
-			self.command_params += ['-testnet']
+		self.jsonRpc = jsonRpc
+
+		blockchainInfo = self.jsonRpc.call("getblockchaininfo", [])
+		actualNet = blockchainInfo['chain']
+
+		netmap = {'main': 'mainnet', 'test': 'testnet', 'regtest': 'regtest'}
+		if netmap[actualNet] != network:
+		    raise Exception('wrong network configured')
+
 		self.notifythread = None
 		self.txnotify_fun = []
 
 	def get_wallet_name(self, wallet):
 		return 'joinmarket-wallet-' + btc.dbl_sha256(wallet.keys[0][0])[:6]
 
-	def rpc(self, args):
-		try:
-			if args[0] != 'importaddress':
-				common.debug('rpc: ' + str(self.command_params + args))
-			res = subprocess.check_output(self.command_params + args)
-			return res
-		except subprocess.CalledProcessError, e:
-			raise #something here
+	def rpc(self, method, args):
+		if method != 'importaddress':
+			common.debug('rpc: ' + method + " " + str(args))
+		res = self.jsonRpc.call(method, args)
+		return res
 
 	def add_watchonly_addresses(self, addr_list, wallet_name):
 		common.debug('importing ' + str(len(addr_list)) + ' addresses into account ' + wallet_name)
 		for addr in addr_list:
-			self.rpc(['importaddress', addr, wallet_name, 'false'])
+			self.rpc('importaddress', [addr, wallet_name, False])
 		if common.config.get("BLOCKCHAIN", "blockchain_source") != 'regtest': 
 			print 'now restart bitcoind with -rescan'
 			sys.exit(0)
@@ -397,18 +406,18 @@ class BitcoinCoreInterface(BlockchainInterface):
 			for forchange in [0, 1]:
 				wallet_addr_list += [wallet.get_new_addr(mix_depth, forchange) for i in range(addr_req_count)]
 				wallet.index[mix_depth][forchange] = 0
-		imported_addr_list = json.loads(self.rpc(['getaddressesbyaccount', wallet_name]))
+		imported_addr_list = self.rpc('getaddressesbyaccount', [wallet_name])
 		if not set(wallet_addr_list).issubset(set(imported_addr_list)):
 			self.add_watchonly_addresses(wallet_addr_list, wallet_name)
 			return
 
-		ret = self.rpc(['listtransactions', wallet_name, '1000', '0', 'true'])
+		ret = self.rpc('listtransactions', [wallet_name, 1000, 0, True])
 		buf = json.loads(ret)
 		txs = buf
 		# If the buffer's full, check for more, until it ain't
 		while len(buf) == 1000:
-			ret = self.rpc(['listtransactions', wallet_name, '1000',
-					str(len(txs)), 'true'])
+			ret = self.rpc('listtransactions', [wallet_name, 1000,
+					len(txs), True])
 			buf = json.loads(ret)
 			txs += buf
 		used_addr_list = [tx['address'] for tx in txs if tx['category'] == 'receive']
@@ -453,7 +462,7 @@ class BitcoinCoreInterface(BlockchainInterface):
 		st = time.time()
 		wallet_name = self.get_wallet_name(wallet)
 		wallet.unspent = {}
-		unspent_list = json.loads(self.rpc(['listunspent']))
+		unspent_list = self.rpc('listunspent', [])
 		for u in unspent_list:
 			if 'account' not in u:
 				continue
@@ -473,33 +482,28 @@ class BitcoinCoreInterface(BlockchainInterface):
 		one_addr_imported = False
 		for outs in txd['outs']:
 			addr = btc.script_to_address(outs['script'], common.get_addr_vbyte())
-			if self.rpc(['getaccount', addr]) != '':
+			if self.rpc('getaccount', [addr]) != '':
 				one_addr_imported = True
 				break
 		if not one_addr_imported:
-			self.rpc(['importaddress', notifyaddr, 'joinmarket-notify', 'false'])
+			self.rpc('importaddress', [notifyaddr, 'joinmarket-notify', False])
 		tx_output_set = set([(sv['script'], sv['value']) for sv in txd['outs']])
 		self.txnotify_fun.append((tx_output_set, unconfirmfun, confirmfun))
 
 	def pushtx(self, txhex):
-		try:
-			return self.rpc(['sendrawtransaction', txhex]).strip()
-		except subprocess.CalledProcessError, e:
-			common.debug('failed pushtx, error ' + repr(e))
-			return None
+		return self.rpc('sendrawtransaction', [txhex])
 
 	def query_utxo_set(self, txout):
 		if not isinstance(txout, list):
 			txout = [txout]
 		result = []
 		for txo in txout:
-			ret = self.rpc(['gettxout', txo[:64], txo[65:], 'false'])
-			if ret == '':
+			ret = self.rpc('gettxout', [txo[:64], int(txo[65:]), False])
+			if ret is None:
 				result.append(None)
 			else:
-				data = json.loads(ret)
-				result.append({'value': int(Decimal(str(data['value']))*Decimal('1e8')),
-					'address': data['scriptPubKey']['addresses'][0], 'script': data['scriptPubKey']['hex']})
+				result.append({'value': int(Decimal(str(ret['value']))*Decimal('1e8')),
+					'address': ret['scriptPubKey']['addresses'][0], 'script': ret['scriptPubKey']['hex']})
 		return result
 
 
@@ -508,9 +512,8 @@ class BitcoinCoreInterface(BlockchainInterface):
 #to be instantiated after network is up
 #with > 100 blocks.
 class RegtestBitcoinCoreInterface(BitcoinCoreInterface):
-	def __init__(self, bitcoin_cli_cmd):
-		super(RegtestBitcoinCoreInterface, self).__init__(bitcoin_cli_cmd, False)
-		self.command_params = bitcoin_cli_cmd + ['-regtest']
+	def __init__(self, jsonRpc):
+		super(RegtestBitcoinCoreInterface, self).__init__(jsonRpc, 'regtest')
 
 	def pushtx(self, txhex):
 		ret = super(RegtestBitcoinCoreInterface, self).pushtx(txhex)
@@ -527,7 +530,7 @@ class RegtestBitcoinCoreInterface(BitcoinCoreInterface):
 	def tick_forward_chain(self, n):
 		'''Special method for regtest only;
 		instruct to mine n blocks.'''
-		self.rpc(['setgenerate','true', str(n)])
+		self.rpc('setgenerate', [True, n])
 
 	def grab_coins(self, receiving_addr, amt=50):
 		'''
@@ -543,12 +546,12 @@ class RegtestBitcoinCoreInterface(BitcoinCoreInterface):
 		if amt > self.current_balance:
 		#mine enough to get to the reqd amt
 		reqd = int(amt - self.current_balance)
-		reqd_blocks = str(int(reqd/50) +1)
-		if self.rpc(['setgenerate','true', reqd_blocks]):
+		reqd_blocks = int(reqd/50) +1
+		if self.rpc('setgenerate', [True, reqd_blocks]):
 		raise Exception("Something went wrong")
 		'''
 		#now we do a custom create transaction and push to the receiver
-		txid = self.rpc(['sendtoaddress', receiving_addr, str(amt)])
+		txid = self.rpc('sendtoaddress', [receiving_addr, amt])
 		if not txid:
 			raise Exception("Failed to broadcast transaction")
 		#confirm
@@ -560,9 +563,9 @@ class RegtestBitcoinCoreInterface(BitcoinCoreInterface):
 		#allow importaddress to fail in case the address is already in the wallet
 		res = []
 		for address in addresses:
-			self.rpc(['importaddress', address,'watchonly'])
+			self.rpc('importaddress', [address, 'watchonly'])
 			res.append({'address':address,'balance':\
-			        int(Decimal(1e8) * Decimal(self.rpc(['getreceivedbyaddress', address])))})
+				int(Decimal(1e8) * Decimal(self.rpc('getreceivedbyaddress', [address])))})
 		return {'data':res}	
 
 def main():

--- a/lib/common.py
+++ b/lib/common.py
@@ -21,7 +21,7 @@ joinmarket_alert = None
 
 config = SafeConfigParser()
 config_location = 'joinmarket.cfg'
-required_options = {'BLOCKCHAIN':['blockchain_source', 'network', 'bitcoin_cli_cmd'],
+required_options = {'BLOCKCHAIN':['blockchain_source', 'network', 'rpc_host', 'rpc_port', 'rpc_user', 'rpc_password'],
                     'MESSAGING':['host','channel','port']}
 
 defaultconfig =\
@@ -31,7 +31,10 @@ blockchain_source = blockr
 #options: blockr, json-rpc, regtest 
 #before using json-rpc read https://github.com/chris-belcher/joinmarket/wiki/Running-JoinMarket-with-Bitcoin-Core-full-node 
 network = mainnet
-bitcoin_cli_cmd = bitcoin-cli
+rpc_host = localhost
+rpc_port = 8332
+rpc_user = bitcoin
+rpc_password = password
 
 [MESSAGING]
 host = irc.cyberguerrilla.org
@@ -314,11 +317,10 @@ class BitcoinCoreWallet(AbstractWallet):
 		self.max_mix_depth = 1
 
 	def get_key_from_addr(self, addr):
-		return bc_interface.rpc(['dumpprivkey', addr]).strip()
+		return bc_interface.rpc('dumpprivkey', [addr])
 
 	def get_utxos_by_mixdepth(self):
-		ret = bc_interface.rpc(['listunspent'])
-		unspent_list = json.loads(ret)
+		unspent_list = bc_interface.rpc('listunspent', [])
 		result = {0: {}}
 		for u in unspent_list:
 			if not u['spendable']:
@@ -330,7 +332,7 @@ class BitcoinCoreWallet(AbstractWallet):
 		return result
 
 	def get_change_addr(self, mixing_depth):
-		return bc_interface.rpc(['getrawchangeaddress']).strip()
+		return bc_interface.rpc('getrawchangeaddress', [])
 
 def calc_cj_fee(ordertype, cjfee, cj_amount):
 	real_cjfee = None

--- a/lib/common.py
+++ b/lib/common.py
@@ -21,14 +21,15 @@ joinmarket_alert = None
 
 config = SafeConfigParser()
 config_location = 'joinmarket.cfg'
-required_options = {'BLOCKCHAIN':['blockchain_source', 'network', 'rpc_host', 'rpc_port', 'rpc_user', 'rpc_password'],
+# FIXME: Add rpc_* options here in the future!
+required_options = {'BLOCKCHAIN':['blockchain_source', 'network'],
                     'MESSAGING':['host','channel','port']}
 
 defaultconfig =\
 """
 [BLOCKCHAIN]
 blockchain_source = blockr 
-#options: blockr, json-rpc, regtest 
+#options: blockr, json-rpc, json-rpc-socket, regtest
 #before using json-rpc read https://github.com/chris-belcher/joinmarket/wiki/Running-JoinMarket-with-Bitcoin-Core-full-node 
 network = mainnet
 rpc_host = localhost

--- a/lib/jsonrpc.py
+++ b/lib/jsonrpc.py
@@ -1,0 +1,115 @@
+# Copyright (C) 2013,2015 by Daniel Kraft <d@domob.eu>
+# Copyright (C) 2014 by phelix / blockchained.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import base64
+import httplib
+import json
+
+class JsonRpcError (Exception):
+  """
+  The called method returned an error in the JSON-RPC response.
+  """
+
+  def __init__ (self, obj):
+    self.code = obj["code"]
+    self.message = obj["message"]
+
+class JsonRpcConnectionError (Exception):
+  """
+  Error thrown when the RPC connection itself failed.  This means
+  that the server is either down or the connection settings
+  are wrong.
+  """
+
+  pass
+
+class JsonRpc (object):
+  """
+  Simple implementation of a JSON-RPC client that is used
+  to connect to Bitcoin.
+  """
+
+  def __init__ (self, host, port, user, password):
+    self.host = host
+    self.port = port
+    self.authstr = "%s:%s" % (user, password)
+
+    self.queryId = 1
+
+  def queryHTTP (self, obj):
+    """
+    Send an appropriate HTTP query to the server.  The JSON-RPC
+    request should be (as object) in 'obj'.  If the call succeeds,
+    the resulting JSON object is returned.  In case of an error
+    with the connection (not JSON-RPC itself), an exception is raised.
+    """
+
+    headers = {}
+    headers["User-Agent"] = "joinmarket"
+    headers["Content-Type"] = "application/json"
+    headers["Accept"] = "application/json"
+    headers["Authorization"] = "Basic %s" % base64.b64encode (self.authstr)
+
+    body = json.dumps (obj)
+
+    try:
+      conn = httplib.HTTPConnection (self.host, self.port)
+      conn.request ("POST", "", body, headers)
+      response = conn.getresponse ()
+
+      if response.status == 401:
+        conn.close ()
+        raise JsonRpcConnectionError ("authentication for JSON-RPC failed")
+
+      # All of the codes below are 'fine' from a JSON-RPC point of view.
+      if response.status not in [200, 404, 500]:
+        conn.close ()
+        raise JsonRpcConnectionError ("unknown error in JSON-RPC")
+
+      data = response.read ()
+      conn.close ()
+
+      return json.loads (data)
+
+    except JsonRpcConnectionError as exc:
+      raise exc
+    except Exception as exc:
+      raise JsonRpcConnectionError ("JSON-RPC connection failed")
+
+  def call (self, method, params):
+    """
+    Call a method over JSON-RPC.
+    """
+
+    currentId = self.queryId
+    self.queryId += 1
+
+    request = {"method": method, "params": params, "id": currentId}
+    response = self.queryHTTP (request)
+
+    if response["id"] != currentId:
+      raise JsonRpcConnectionError ("invalid id returned by query")
+
+    if response["error"] is not None:
+      print response["error"]
+      raise JsonRpcError (response["error"])
+
+    return response["result"]


### PR DESCRIPTION
Replace the connection to Bitcoin Core via bitcoin-cli by a connection through its JSON-RPC interface.  This is cleaner, as it does not require to convert everything to/from strings.  It is also able to handle error codes.

See https://github.com/chris-belcher/joinmarket/issues/137.

I have tested that it works successfully for a `sendpayment.py` order.  More testing would probably be good, though.