### PR TITLE
implement userpcwallet for patientsendpayment.py

### DIFF
--- a/patientsendpayment.py
+++ b/patientsendpayment.py
@@ -150,8 +150,6 @@ def main():
 	if not options.userpcwallet:
 		wallet = Wallet(wallet_name, options.mixdepth + 1)
 	else:
-		print 'not implemented yet'
-		sys.exit(0)
 		wallet = BitcoinCoreWallet(fromaccount = wallet_name)
 	common.bc_interface.sync_wallet(wallet)
 


### PR DESCRIPTION
Was there a reason this has been left disabled?  I was able to initiate a patientsend via rpc (although never got a taker).  Everything seemed okay.  Curious if something else needs to be done to finalize this.  Thanks.