### PR TITLE
alphabatize gitignore and ignore env for virtualenvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
 *.swp
-joinmarket.cfg
 blockchain.cache
+env
+joinmarket.cfg


### PR DESCRIPTION
I setup my app with `virtualenv env; . env/bin/activate; pip install numpy`

This will ignore the env directory. "env" is a pretty standard although sometimes people instead do "pyenv" or ".env"