### PR TITLE
Revert "bug fix" (that just introduced another)

### DIFF
--- a/lib/maker.py
+++ b/lib/maker.py
@@ -116,7 +116,8 @@ class CoinJoinOrder(object):
 		finally:
 			self.maker.wallet_unspent_lock.release()
 		debug('tx in a block')
-                to_cancel, to_announce = self.maker.on_tx_confirmed(self, cjorder, confirmations, txid)
+		to_cancel, to_announce = self.maker.on_tx_confirmed(self,
+			confirmations, txid)
 		self.maker.modify_orders(to_cancel, to_announce)
 
 	def verify_unsigned_tx(self, txd):


### PR DESCRIPTION
Reverts chris-belcher/joinmarket#135

```
  File "/home/less/joinmarket/lib/maker.py", line 119, in confirm_callback
    to_cancel, to_announce = self.maker.on_tx_confirmed(self, cjorder, confirmations, txid)
NameError: global name 'cjorder' is not defined
```