### PR TITLE
consolidate rate limit into IRCMessageChannel.__privmsg()

### DIFF
--- a/lib/irc.py
+++ b/lib/irc.py
@@ -99,7 +99,6 @@ class IRCMessageChannel(MessageChannel):
 		txb64 = base64.b64encode(txhex.decode('hex'))
 		for nick in nick_list:
 			self.__privmsg(nick, 'tx', txb64)
-			time.sleep(1) #HACK! really there should be rate limiting, see issue#31
 
 	def push_tx(self, nick, txhex):
 		txb64 = base64.b64encode(txhex.decode('hex'))
@@ -138,7 +137,6 @@ class IRCMessageChannel(MessageChannel):
 		#TODO make it send the sigs on one line if there's space
 		for s in sig_list:
 			self.__privmsg(nick, 'sig', s)
-			time.sleep(0.5) #HACK! really there should be rate limiting, see issue#31
 
 	def __pubmsg(self, message):
 		debug('>>pubmsg ' + message)
@@ -164,6 +162,7 @@ class IRCMessageChannel(MessageChannel):
 			if m==message_chunks[0]:
 				m = COMMAND_PREFIX + cmd + ' ' + m
 			self.send_raw(header + m + trailer)
+			time.sleep(1) # TODO: proper rate limiting, cf issue#31
 
 	def send_raw(self, line):
 		#if not line.startswith('PING LAG'):


### PR DESCRIPTION
All too often, I've seen takers get kicked by the IRC server for flooding,
appearing in the logs as "QUIT :RecvQ Exceeded". Most often this happens in the
stage when they send the unsigned transaction to their selected makers, and this
commit makes it so all communication to the server is sufficiently delayed to
comply with all but the most draconian of rate limits.

Progresses towards a solution for #31