### PR TITLE
IOError when using wallets/wallet.json argument. Looks for wallets/wa…

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -191,7 +191,9 @@ class Wallet(AbstractWallet):
 	def get_seed(self, seedarg):
 		self.path = None
 		self.index_cache = [[0, 0]]*self.max_mix_depth
-		path = os.path.join('wallets', seedarg)
+
+		path = seedarg
+
 		if not os.path.isfile(path):
 			if get_network() == 'testnet':
 				debug('seedarg interpreted as seed, only available in testnet because this probably has lower entropy')

--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -112,10 +112,20 @@ elif method == 'generate' or method == 'recover':
 	walletname = raw_input('Input wallet file name (default: wallet.json): ')
 	if len(walletname) == 0:
 		walletname = 'wallet.json'
-	fd = open(os.path.join('wallets', walletname), 'w')
-	fd.write(walletfile)
-	fd.close()
-	print 'saved to ' + walletname
+	walletpath = os.path.join('wallets', walletname)
+	if os.path.isfile(walletpath):
+		print walletpath + ' already exists. Do you want to overwrite it? (y/n)'
+		print 'Bitcoins from the overwritten wallet will be lost!'
+		answer = raw_input()
+		if answer == 'y':
+			fd = open(walletpath, 'w')
+			fd.write(walletfile)
+			fd.close()	
+			print 'saved to ' + walletname
+		else:
+			print 'Wallet not overwritten.'
+	else:
+		print 'saved to ' + walletname
 elif method == 'showseed':
 	hexseed = wallet.seed
 	print 'hexseed = ' + hexseed


### PR DESCRIPTION
Just a small fix.

running

$ python wallet-tool.py wallets/wallet.json
(where wallet is saved after generation)

returned

Traceback (most recent call last):
  File "wallet-tool.py", line 52, in <module>
    wallet = Wallet(seed, options.maxmixdepth, options.gaplimit)
  File "/storage/Coinstuff/joinmarket/lib/common.py", line 172, in __init__
    self.seed = self.get_seed(seedarg)
  File "/storage/Coinstuff/joinmarket/lib/common.py", line 200, in get_seed
    raise IOError('wallet file not found')
IOError: wallet file not found

The wallet is checked for existence, which fails because the path is actually wallets/wallets/wallet.json

