### PR TITLE
prevent sendpayment.py dos

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -335,7 +335,7 @@ class BitcoinCoreWallet(AbstractWallet):
 def calc_cj_fee(ordertype, cjfee, cj_amount):
 	real_cjfee = None
 	if ordertype == 'absorder':
-		real_cjfee = int(cjfee)
+		real_cjfee = float(cjfee)
 	elif ordertype == 'relorder':
 		real_cjfee = int((Decimal(cjfee) * Decimal(cj_amount)).quantize(Decimal(1)))
 	else:

--- a/lib/common.py
+++ b/lib/common.py
@@ -337,11 +337,15 @@ def calc_cj_fee(ordertype, cjfee, cj_amount):
         if ordertype == 'absorder':
                 try:
                         real_cjfee = int(cjfee)
-                except ValueError as e:
+                except Exception as e:
                         debug("WARN: calc_cf_fee error: (" + str(e) + ") - setting invalid cjfee to 1000 BTC then continuing... ")
                         real_cjfee = int(100000000000)
         elif ordertype == 'relorder':
-                real_cjfee = int((Decimal(cjfee) * Decimal(cj_amount)).quantize(Decimal(1)))
+        	try:
+                	real_cjfee = int((Decimal(cjfee) * Decimal(cj_amount)).quantize(Decimal(1)))
+                except Exception as e:
+                	debug("WARN: calc_cf_fee error: (" + str(e) + ") - setting invalid cjfee to 1000 BTC then continuing... ")
+                        real_cjfee = int(100000000000)
         else:
                 raise RuntimeError('unknown order type: ' + str(ordertype))
         return real_cjfee

--- a/lib/common.py
+++ b/lib/common.py
@@ -333,14 +333,18 @@ class BitcoinCoreWallet(AbstractWallet):
 		return bc_interface.rpc(['getrawchangeaddress']).strip()
 
 def calc_cj_fee(ordertype, cjfee, cj_amount):
-	real_cjfee = None
-	if ordertype == 'absorder':
-		real_cjfee = float(cjfee)
-	elif ordertype == 'relorder':
-		real_cjfee = int((Decimal(cjfee) * Decimal(cj_amount)).quantize(Decimal(1)))
-	else:
-		raise RuntimeError('unknown order type: ' + str(ordertype))
-	return real_cjfee
+        real_cjfee = None
+        if ordertype == 'absorder':
+                try:
+                        real_cjfee = int(cjfee)
+                except ValueError as e:
+                        debug("WARN: calc_cf_fee error: (" + str(e) + ") - setting invalid cjfee to 1000 BTC then continuing... ")
+                        real_cjfee = int(100000000000)
+        elif ordertype == 'relorder':
+                real_cjfee = int((Decimal(cjfee) * Decimal(cj_amount)).quantize(Decimal(1)))
+        else:
+                raise RuntimeError('unknown order type: ' + str(ordertype))
+        return real_cjfee
 
 def weighted_order_choose(orders, n, feekey):
 	'''


### PR DESCRIPTION
A poorly coded or malicious maker bot script may be able to cause all potential takers to hang when seeking available orders, with something like

    ValueError: invalid literal for int() with base 10: '0.1337'

This is done by making certain changes to how the maker order is announced to potential takers in IRC.

Change int to float instead possibly to avoid hanging?  Not sure what else this may affect or if this is the best solution, in any case, but this is a potential way to deny service to takers, so please review ASAP.