### PR TITLE
update default tor config

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -43,8 +43,8 @@ socks5_host = localhost
 socks5_port = 9150
 #for tor
 #host = 6dvj6v5imhny3anf.onion
-#port = 6667
-#usessl = false
+#port = 6697
+#usessl = true
 #socks5 = true
 """
 

--- a/lib/common.py
+++ b/lib/common.py
@@ -40,7 +40,7 @@ port = 6697
 usessl = true
 socks5 = false
 socks5_host = localhost
-socks5_port = 9150
+socks5_port = 9050
 #for tor
 #host = 6dvj6v5imhny3anf.onion
 #port = 6697


### PR DESCRIPTION
update default tor config: 6dvj6v5imhny3anf.onion uses port 6697 and requires ssl authentication currently.

https://cyberguerrilla.info/ways-to-connect-to-cgan-irc/

Tor opens a socks proxy on port 9050 by default

[TBBSocksPort](https://www.torproject.org/docs/faq.html.en#TBBSocksPort)