### PR TITLE
standardize satoshi_to_unit output

### DIFF
--- a/ob-watcher.py
+++ b/ob-watcher.py
@@ -99,7 +99,7 @@ def cjfee_display(cjfee, order):
 		return str(float(cjfee) * 100) + '%'
 
 def satoshi_to_unit(sat, order):
-	return str(Decimal(sat) / Decimal(1e8))
+	return "%.8f" % float(Decimal(sat) / Decimal(1e8))
 
 def order_str(s, order):
 	return str(s)


### PR DESCRIPTION
cleans up the display of units returned for the orderbook.  only affects decimal output of fees and min/max size display.

see [this display with clean satoshi display](http://bitcoin-p2pool.com/joinmarket_orderbook.html) vs [this current style of display](http://joinmarket.io/)

edit, both of the above are now using (variations of) this PR.