### PR TITLE
ensure correct password

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -218,7 +218,12 @@ class Wallet(AbstractWallet):
 			try:
 				decrypted_seed = slowaes.decryptData(password_key, encrypted_seed
 					.decode('hex')).encode('hex')
-				decrypted = True
+				#there is a small probability of getting a valid PKCS7 padding
+				#by chance from a wrong password; sanity check the seed length
+				if len(decrypted_seed) == 32:
+					decrypted = True
+				else:
+					raise ValueError
 			except ValueError:
 				print 'Incorrect password'
 				decrypted = False

--- a/lib/slowaes.py
+++ b/lib/slowaes.py
@@ -27,6 +27,8 @@ def strip_PKCS7_padding(s):
     numpads = ord(s[-1])
     if numpads > 16:
         raise ValueError("String ending with %r can't be PCKS7-padded" % s[-1])
+    if not all(numpads == x for x in map(ord,s[-numpads:-1])):
+        raise ValueError("Invalid PKCS7 padding")
     return s[:-numpads]
 
 class AES(object):


### PR DESCRIPTION
PKCS7 padding has the form: 01 or 0202 or 030303 etc. For a correctly entered password and a correct decryption, there will be a full block of padding at the end of the data: 1010... (16 times, hex). This obviously cannot happen by chance, which is why entering an incorrect password throws a ValueError which the current code then interprets as decryption failure and requests the user to try again.

However, in the case where an entered password is incorrect, it is possible that the decrypted data (*before* stripping the padding) ends with ..01. This would be interpreted as correctly pkcs7 padded, the 01 would be stripped, and a decrypted seed of length 32+15 = 47 bytes would be returned. No ValueError would be thrown and then a bip 32 master seed would be correctly (but randomly) generated. Note that the bip32 master key generation uses an hmac of the seed data, and so the seed data length is ignored.

So in summary we have a slightly bigger than 1 in 256 chance of a wrong password being accepted here, so this PR insists that the decrypted data has a length of 32 bytes, making this error impossible.

I don't consider this a big deal really, but it's as well to fix it of course. I was 'inspired' by #190 , but there seems to be no chance that this was the cause of the strange behaviour described there.