### PR TITLE
sanity check length of recovery seed

### DIFF
--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -96,7 +96,10 @@ elif method == 'generate' or method == 'recover':
 		print 'Write down this wallet recovery seed\n\n' + ' '.join(words) + '\n'
 	elif method == 'recover':
 		words = raw_input('Input 12 word recovery seed: ')
-		words = words.split(' ')
+		words = words.split() #default for split is 1 or more whitespace chars
+		if len(words) != 12:
+			print 'ERROR. Recovery seed phrase must be exactly 12 words.'
+			sys.exit(0)
 		seed = old_mnemonic.mn_decode(words)
 		print seed
 	password = getpass.getpass('Enter wallet encryption passphrase: ')


### PR DESCRIPTION
The issue that this addresses starts in #190 and continues/finishes in the [reddit thread](https://www.reddit.com/r/joinmarket/comments/3h0vyy/alert_someone_sent_coins_to_and_has_been_using_a/).

The fix is trivial, just checking that the seed phrase entered is 12 words.  While doing it, I noticed that .split(' ') has the unfortunate effect of treating extra spaces as extra words (so 'a b  c'.split(' ') comes out as ['a',b','','c'] which is undesirable if nothing else because it gives a misleading error). So I've edited it to .split() because this will split on any amount of whitespace, which is a more expected behaviour.

A perhaps more 'meta' conclusion from all this is to look again at sanity checking user input generally, and don't assume that used libraries (slowaes, old_mnemonic) are doing sanity checks at the lower level. I personally had never even looked at that code (even slowaes, although I used it before I never tried to use the high level 'encryptData' which does the padding for you).