### PR TITLE
Try to unlock RPC wallet if it is locked.

### DIFF
--- a/lib/blockchaininterface.py
+++ b/lib/blockchaininterface.py
@@ -427,7 +427,7 @@ class BitcoinCoreInterface(BlockchainInterface):
 		return 'joinmarket-wallet-' + btc.dbl_sha256(wallet.keys[0][0])[:6]
 
 	def rpc(self, method, args):
-		if method != 'importaddress':
+		if method not in ['importaddress', 'walletpassphrase']:
 			common.debug('rpc: ' + method + " " + str(args))
 		res = self.jsonRpc.call(method, args)
 		if isinstance(res, unicode):

--- a/lib/common.py
+++ b/lib/common.py
@@ -4,7 +4,7 @@ from decimal import Decimal, InvalidOperation
 from math import factorial, exp
 import sys, datetime, json, time, pprint, threading, getpass
 import random
-import blockchaininterface, slowaes
+import blockchaininterface, jsonrpc, slowaes
 from ConfigParser import SafeConfigParser, NoSectionError, NoOptionError
 import os, io, itertools
 
@@ -437,6 +437,7 @@ class BitcoinCoreWallet(AbstractWallet):
 		self.max_mix_depth = 1
 
 	def get_key_from_addr(self, addr):
+		self.ensure_wallet_unlocked()
 		return bc_interface.rpc('dumpprivkey', [addr])
 
 	def get_utxos_by_mixdepth(self):
@@ -453,6 +454,22 @@ class BitcoinCoreWallet(AbstractWallet):
 
 	def get_change_addr(self, mixing_depth):
 		return bc_interface.rpc('getrawchangeaddress', [])
+
+	def ensure_wallet_unlocked(self):
+		wallet_info = bc_interface.rpc('getwalletinfo', [])
+		if 'unlocked_until' in wallet_info and wallet_info['unlocked_until'] <= 0:
+			while True:
+				password = getpass.getpass('Enter passphrase to unlock wallet: ')
+				if password == '':
+					raise RuntimeError('Aborting wallet unlock')
+				try:
+					#TODO cleanly unlock wallet after use, not with arbitrary timeout
+					bc_interface.rpc('walletpassphrase', [password, 10])
+					break
+				except jsonrpc.JsonRpcError as exc:
+					if exc.code != -14:
+						raise exc
+					# Wrong passphrase, try again.
 
 def calc_cj_fee(ordertype, cjfee, cj_amount):
 	real_cjfee = None


### PR DESCRIPTION
When `--rpcwallet` is used and the wallet is locked, ask the user for a passphrase to unlock the wallet before using it.

This only works when using the new JSON-RPC interface instead of the CLI tool.