### PR TITLE
Crude maker-timeout recovery by taker

### DIFF
--- a/lib/taker.py
+++ b/lib/taker.py
@@ -7,35 +7,45 @@ import bitcoin as btc
 
 import sqlite3, base64, threading, time, random, pprint
 
+MAKER_RESPONSE_TIMEOUT = 10 #in seconds
+
 class CoinJoinTX(object):
 	#soon the taker argument will be removed and just be replaced by wallet or some other interface
 	def __init__(self, msgchan, wallet, db, cj_amount, orders, input_utxos, my_cj_addr,
-		my_change_addr, my_txfee, finishcallback=None):
+		my_change_addr, my_txfee, finishcallback, choose_orders_recover):
 		'''
 		if my_change is None then there wont be a change address
 		thats used if you want to entirely coinjoin one utxo with no change left over
 		orders is the orders you want to fill {'counterpartynick': oid, 'cp2': oid2}
 		'''
 		debug('starting cj to ' + my_cj_addr + ' with change at ' + str(my_change_addr))
+		#parameters
 		self.msgchan = msgchan
 		self.wallet = wallet
 		self.db = db
 		self.cj_amount = cj_amount
 		self.active_orders = dict(orders)
-		self.nonrespondants = list(orders.keys())
 		self.input_utxos = input_utxos
-		self.utxos = {None: input_utxos.keys()} #None means they belong to me
 		self.finishcallback = finishcallback
 		self.my_txfee = my_txfee
-		self.outputs = [{'address': my_cj_addr, 'value': self.cj_amount}]
 		self.my_cj_addr = my_cj_addr
 		self.my_change_addr = my_change_addr
+		self.choose_orders_recover = choose_orders_recover
+		self.timeout_lock = threading.Condition()
+		self.end_timeout_thread = False
+		CoinJoinTX.TimeoutThread(self).start()
+		#state variables
+		self.txid = None
 		self.cjfee_total = 0
+		self.nonrespondants = list(self.active_orders.keys())
+		self.all_responded = False
 		self.latest_tx = None
+		self.utxos = {None: self.input_utxos.keys()} #None means they belong to me
+		self.outputs = [{'address': self.my_cj_addr, 'value': self.cj_amount}]
 		#create DH keypair on the fly for this Tx object
 		self.kp = enc_wrapper.init_keypair()
 		self.crypto_boxes = {}
-		self.msgchan.fill_orders(orders, cj_amount, self.kp.hex_pk())
+		self.msgchan.fill_orders(self.active_orders, self.cj_amount, self.kp.hex_pk())
 
 	def start_encryption(self, nick, maker_pk):
 		if nick not in self.active_orders.keys():
@@ -55,7 +65,7 @@ class CoinJoinTX(object):
 		with an ecdsa verification.'''
 		#crypto_boxes[nick][0] = maker_pubkey
 		if not btc.ecdsa_verify(self.crypto_boxes[nick][0], btc_sig, cj_pub):
-			print 'signature didnt match pubkey and message'
+			debug('signature didnt match pubkey and message')
 			return False
 		return True
 	
@@ -76,8 +86,8 @@ class CoinJoinTX(object):
 		real_cjfee = calc_cj_fee(order['ordertype'], order['cjfee'], self.cj_amount)
 		self.outputs.append({'address': change_addr, 'value':
 			total_input - self.cj_amount - order['txfee'] + real_cjfee})
-		print 'fee breakdown for %s totalin=%d cjamount=%d txfee=%d realcjfee=%d' % (nick,
-			total_input, self.cj_amount, order['txfee'], real_cjfee)
+		debug('fee breakdown for %s totalin=%d cjamount=%d txfee=%d realcjfee=%d' % (nick,
+			total_input, self.cj_amount, order['txfee'], real_cjfee))
 		cj_addr = btc.pubtoaddr(cj_pub, get_addr_vbyte())
 		self.outputs.append({'address': cj_addr, 'value': self.cj_amount})
 		self.cjfee_total += real_cjfee
@@ -85,7 +95,12 @@ class CoinJoinTX(object):
 		if len(self.nonrespondants) > 0:
 			debug('nonrespondants = ' + str(self.nonrespondants))
 			return
+		self.all_responded = True
+		self.timeout_lock.acquire()
+		self.timeout_lock.notify()
+		self.timeout_lock.release()
 		debug('got all parts, enough to build a tx cjfeetotal=' + str(self.cjfee_total))
+		self.nonrespondants = list(self.active_orders.keys())
 
 		my_total_in = 0
 		for u, va in self.input_utxos.iteritems():
@@ -93,13 +108,13 @@ class CoinJoinTX(object):
 		#my_total_in = sum([va['value'] for u, va in self.input_utxos.iteritems()])
 
 		my_change_value = my_total_in - self.cj_amount - self.cjfee_total - self.my_txfee
-		print 'fee breakdown for me totalin=%d txfee=%d cjfee_total=%d => changevalue=%d' % (my_total_in, 
-			self.my_txfee, self.cjfee_total, my_change_value)
+		debug('fee breakdown for me totalin=%d txfee=%d cjfee_total=%d => changevalue=%d' % (my_total_in, 
+			self.my_txfee, self.cjfee_total, my_change_value))
 		if self.my_change_addr == None:
 			if my_change_value != 0 and abs(my_change_value) != 1:
 				#seems you wont always get exactly zero because of integer rounding
 				# so 1 satoshi extra or fewer being spent as miner fees is acceptable
-				print 'WARNING CHANGE NOT BEING USED\nCHANGEVALUE = ' + str(my_change_value)
+				debug('WARNING CHANGE NOT BEING USED\nCHANGEVALUE = ' + str(my_change_value))
 		else:
 			self.outputs.append({'address': self.my_change_addr, 'value': my_change_value})
 		utxo_tx = [dict([('output', u)]) for u in sum(self.utxos.values(), [])]
@@ -118,7 +133,7 @@ class CoinJoinTX(object):
 			tx = btc.sign(tx, index, self.wallet.get_key_from_addr(addr))
 		self.latest_tx = btc.deserialize(tx)
 
-	def add_signature(self, sigb64):
+	def add_signature(self, nick, sigb64):
 		sig = base64.b64decode(sigb64).encode('hex')
 		inserted_sig = False
 		tx = btc.serialize(self.latest_tx)
@@ -134,6 +149,11 @@ class CoinJoinTX(object):
 				debug('found good sig at index=%d' % (index))
 				ins['script'] = sig
 				inserted_sig = True
+				#check if maker has sent everything possible
+				self.utxos[nick].remove(utxo)
+				if len(self.utxos[nick]) == 0:
+					debug('nick = ' + nick + ' sent all sigs, removing from nonrespondant list')
+					self.nonrespondants.remove(nick)
 				break
 		if not inserted_sig:
 			debug('signature did not match anything in the tx')
@@ -147,18 +167,82 @@ class CoinJoinTX(object):
 				tx_signed = False
 		if not tx_signed:
 			return
+		self.all_responded = True
+		self.timeout_lock.acquire()
+		self.timeout_lock.notify()
+		self.timeout_lock.release()
 		debug('the entire tx is signed, ready to pushtx()')
 		txhex = btc.serialize(self.latest_tx)
 		debug('\n' + txhex)
+		self.txid = btc.txhash(txhex)
+		debug('pushing tx ' + self.txid)
 
 		#TODO send to a random maker or push myself
 		#self.msgchan.push_tx(self.active_orders.keys()[0], txhex)	
-		self.txid = common.bc_interface.pushtx(txhex)
-		debug('pushed tx ' + str(self.txid))
-		if self.txid == None:
+		ret = common.bc_interface.pushtx(txhex)
+		if ret == None:
 			debug('unable to pushtx')
+		self.end_timeout_thread = True
 		if self.finishcallback != None:
 			self.finishcallback(self)
+
+	def recover_from_nonrespondants(self):
+		debug('nonresponding makers = ' + str(self.nonrespondants))
+		#if there is no choose_orders_recover then end and call finishcallback
+		# so the caller can handle it in their own way, notable for sweeping
+		# where simply replacing the makers wont work
+		if not self.choose_orders_recover:
+			self.end_timeout_thread = True
+			if self.finishcallback != None:
+				self.finishcallback(self)
+			return
+
+		if self.latest_tx == None:
+			#nonresponding to !fill, recover by finding another maker
+			debug('nonresponse to !fill')
+			for nr in self.nonrespondants:
+				del self.active_orders[nr]
+			new_orders, new_makers_fee = self.choose_orders_recover(self.cj_amount,
+				len(self.nonrespondants), self.nonrespondants, self.active_orders.keys())
+			for nick, order in new_orders.iteritems():
+				self.active_orders[nick] = order
+			self.nonrespondants = list(new_orders.keys())
+			debug('new active_orders = \n' + pprint.pformat(self.active_orders) +
+				'new nonrespondants = \n' + pprint.pformat(self.nonrespondants))
+			self.msgchan.fill_orders(new_orders, self.cj_amount, self.kp.hex_pk())
+		else:
+			debug('nonresponse to !sig')
+			#nonresponding to !sig, have to restart tx from the beginning
+			self.end_timeout_thread = True
+			if self.finishcallback != None:
+				self.finishcallback(self)
+			#finishcallback will check if self.txid is None and will know it came from here
+
+	class TimeoutThread(threading.Thread):
+		def __init__(self, cjtx):
+			threading.Thread.__init__(self)
+			self.cjtx = cjtx
+
+		def run(self):
+			debug('started timeout thread for coinjoin of amount ' +
+				str(self.cjtx.cj_amount) + ' to addr ' + self.cjtx.my_cj_addr)
+
+			#how the threading to check for nonresponding makers works like this
+			#there is a Condition object
+			#in a loop, call cond.wait(timeout)
+			# after it returns, check a boolean
+			# to see if if the messages have arrived
+			while not self.cjtx.end_timeout_thread:
+				debug('waiting for all replies..')
+				self.cjtx.timeout_lock.acquire()
+				self.cjtx.timeout_lock.wait(MAKER_RESPONSE_TIMEOUT)
+				self.cjtx.timeout_lock.release()
+				if self.cjtx.all_responded:
+					debug('timeout thread woken by notify(), makers responded in time')
+					self.cjtx.all_responded = False
+				else:
+					debug('timeout thread woken by timeout, makers didnt respond')
+					self.cjtx.recover_from_nonrespondants()
 
 class CoinJoinerPeer(object):
 	def __init__(self, msgchan):
@@ -245,15 +329,15 @@ class Taker(OrderbookWatch):
 		self.maker_pks = {}
 		#TODO have a list of maker's nick we're coinjoining with, so
 		# that some other guy doesnt send you confusing stuff
-		#maybe a start_cj_tx() method is needed
 
 	def get_crypto_box_from_nick(self, nick):
 		return self.cjtx.crypto_boxes[nick][1] #libsodium encryption object
 
 	def start_cj(self, wallet, cj_amount, orders, input_utxos, my_cj_addr, my_change_addr,
-			my_txfee, finishcallback=None):
+			my_txfee, finishcallback=None, choose_orders_recover=None):
 		self.cjtx = CoinJoinTX(self.msgchan, wallet, self.db, cj_amount, orders,
-			input_utxos, my_cj_addr, my_change_addr, my_txfee, finishcallback)
+			input_utxos, my_cj_addr, my_change_addr, my_txfee, finishcallback,
+			choose_orders_recover)
 
 	def on_error(self):
 		pass #TODO implement
@@ -263,13 +347,13 @@ class Taker(OrderbookWatch):
 
 	def on_ioauth(self, nick, utxo_list, cj_pub, change_addr, btc_sig):
 		if not self.cjtx.auth_counterparty(nick, btc_sig, cj_pub):
-			print 'Authenticated encryption with counterparty: ' + nick + \
-			' not established. TODO: send rejection message'
+			debug('Authenticated encryption with counterparty: ' + nick + \
+			' not established. TODO: send rejection message')
 			return				
 		self.cjtx.recv_txio(nick, utxo_list, cj_pub, change_addr)
 
 	def on_sig(self, nick, sig):
-		self.cjtx.add_signature(sig)
+		self.cjtx.add_signature(nick, sig)
 
 if __name__ == "__main__":
 	main()

--- a/patientsendpayment.py
+++ b/patientsendpayment.py
@@ -34,7 +34,7 @@ class TakerThread(threading.Thread):
 		print 'giving up waiting'
 		#cancel the remaining order
 		self.tmaker.modify_orders([0], [])
-		orders, total_cj_fee = choose_order(self.tmaker.db, self.tmaker.amount, self.tmaker.makercount, weighted_order_choose)
+		orders, total_cj_fee = choose_orders(self.tmaker.db, self.tmaker.amount, self.tmaker.makercount, weighted_order_choose)
 		print 'chosen orders to fill ' + str(orders) + ' totalcjfee=' + str(total_cj_fee)
 		total_amount = self.tmaker.amount + total_cj_fee + self.tmaker.txfee
 		print 'total amount spent = ' + str(total_amount)

--- a/tumbler.py
+++ b/tumbler.py
@@ -75,6 +75,8 @@ class TumblerThread(threading.Thread):
 		threading.Thread.__init__(self)
 		self.daemon = True
 		self.taker = taker
+		self.ignored_makers = []
+		self.sweeping = False
 
 	def unconfirm_callback(self, txd, txid):
 		debug('that was %d tx out of %d' % (self.current_tx+1, len(self.taker.tx_list)))
@@ -86,11 +88,78 @@ class TumblerThread(threading.Thread):
 		self.lockcond.release()
 
 	def finishcallback(self, coinjointx):
-		common.bc_interface.add_tx_notify(coinjointx.latest_tx,
-			self.unconfirm_callback, self.confirm_callback, coinjointx.my_cj_addr)
-		self.taker.wallet.remove_old_utxos(coinjointx.latest_tx)
+		if coinjointx.txid:
+			common.bc_interface.add_tx_notify(coinjointx.latest_tx,
+				self.unconfirm_callback, self.confirm_callback, coinjointx.my_cj_addr)
+			self.taker.wallet.remove_old_utxos(coinjointx.latest_tx)
+		else:
+			self.ignored_makers += coinjointx.nonrespondants
+			debug('recreating the tx, ignored_makers=' + str(self.ignored_makers))
+			self.create_tx()
 
-	def send_tx(self, tx, balance, sweep):
+	def tumbler_choose_orders(self, cj_amount, makercount, nonrespondants=[], active_nicks=[]):
+		self.ignored_makers += nonrespondants
+		while True:
+			orders, total_cj_fee = choose_orders(self.taker.db, cj_amount,
+				makercount, weighted_order_choose, self.ignored_makers + active_nicks)
+			cj_fee = 1.0*total_cj_fee / makercount / cj_amount
+			debug('average fee = ' + str(cj_fee))
+
+			if cj_fee > self.taker.maxcjfee:
+				debug('cj fee higher than maxcjfee at ' + str(cj_fee) + ', waiting 60 seconds')
+				time.sleep(60)
+				continue
+			if orders == None:
+				debug('waiting for liquidity 1min, hopefully more orders should come in')
+				time.sleep(60)
+				continue
+			break
+		debug('chosen orders to fill ' + str(orders) + ' totalcjfee=' + str(total_cj_fee))
+		return orders, total_cj_fee
+
+	def create_tx(self):
+		utxos = None
+		orders = None
+		cj_amount = 0
+		change_addr = None
+		choose_orders_recover = None
+		if self.sweep:
+			debug('sweeping')
+			utxos = self.taker.wallet.get_utxos_by_mixdepth()[self.tx['srcmixdepth']]
+			total_value = sum([addrval['value'] for addrval in utxos.values()])
+			while True:
+				orders, cj_amount = choose_sweep_orders(self.taker.db, total_value,
+					self.taker.txfee, self.tx['makercount'], weighted_order_choose,
+					self.ignored_makers)
+				if orders == None:
+					debug('waiting for liquidity 1min, hopefully more orders should come in')
+					time.sleep(60)
+					continue
+				cj_fee = 1.0*(cj_amount - total_value) / self.tx['makercount'] / cj_amount
+				debug('average fee = ' + str(cj_fee))
+				if cj_fee > self.taker.maxcjfee:
+					print 'cj fee higher than maxcjfee at ' + str(cj_fee) + ', waiting 60 seconds'
+					time.sleep(60)
+					continue
+				break
+		else:
+			cj_amount = int(self.tx['amount_fraction'] * self.balance)
+			if cj_amount < self.taker.mincjamount:
+				debug('cj amount too low, bringing up')
+				cj_amount = self.taker.mincjamount
+			change_addr = self.taker.wallet.get_change_addr(self.tx['srcmixdepth'])
+			debug('coinjoining ' + str(cj_amount) + ' satoshi')
+			orders, total_cj_fee = self.tumbler_choose_orders(cj_amount, self.tx['makercount'])
+			total_amount = cj_amount + total_cj_fee + self.taker.txfee
+			debug('total amount spent = ' + str(total_amount))
+			utxos = self.taker.wallet.select_utxos(self.tx['srcmixdepth'], cj_amount)
+			choose_orders_recover = self.tumbler_choose_orders
+
+		self.taker.start_cj(self.taker.wallet, cj_amount, orders, utxos,
+			self.destaddr, change_addr, self.taker.txfee,
+			self.finishcallback, choose_orders_recover)
+
+	def init_tx(self, tx, balance, sweep):
 		destaddr = None
 		if tx['destination'] == 'internal':
 			destaddr = self.taker.wallet.get_receive_addr(tx['srcmixdepth'] + 1)
@@ -103,54 +172,11 @@ class TumblerThread(threading.Thread):
 				print 'Address ' + destaddr + ' invalid. ' + errormsg + ' try again'
 		else:
 			destaddr = tx['destination']
-
-		if sweep:
-			debug('sweeping')
-			all_utxos = self.taker.wallet.get_utxos_by_mixdepth()[tx['srcmixdepth']]
-			total_value = sum([addrval['value'] for addrval in all_utxos.values()])
-			while True:
-				orders, cjamount = choose_sweep_order(self.taker.db, total_value, self.taker.txfee, tx['makercount'], weighted_order_choose)
-				if orders == None:
-					debug('waiting for liquidity 1min, hopefully more orders should come in')
-					time.sleep(60)
-					continue
-				cj_fee = 1.0*(cjamount - total_value) / tx['makercount'] / cjamount
-				debug('average fee = ' + str(cj_fee))
-				if cj_fee > self.taker.maxcjfee:
-					print 'cj fee higher than maxcjfee at ' + str(cj_fee) + ', waiting 60 seconds'
-					time.sleep(60)
-					continue
-				break
-			self.taker.start_cj(self.taker.wallet, cjamount, orders, all_utxos, destaddr,
-				None, self.taker.txfee, self.finishcallback)
-		else:
-			amount = int(tx['amount_fraction'] * balance)
-			if amount < self.taker.mincjamount:
-				debug('cj amount too low, bringing up')
-				amount = self.taker.mincjamount
-			changeaddr = self.taker.wallet.get_change_addr(tx['srcmixdepth'])
-			debug('coinjoining ' + str(amount) + ' satoshi')
-			while True:
-				orders, total_cj_fee = choose_order(self.taker.db, amount, tx['makercount'], weighted_order_choose)
-				cj_fee = 1.0*total_cj_fee / tx['makercount'] / amount
-				debug('average fee = ' + str(cj_fee))
-
-				if cj_fee > self.taker.maxcjfee:
-					debug('cj fee higher than maxcjfee at ' + str(cj_fee) + ', waiting 60 seconds')
-					time.sleep(60)
-					continue
-				if orders == None:
-					debug('waiting for liquidity 1min, hopefully more orders should come in')
-					time.sleep(60)
-					continue
-				break
-			debug('chosen orders to fill ' + str(orders) + ' totalcjfee=' + str(total_cj_fee))
-			total_amount = amount + total_cj_fee + self.taker.txfee
-			debug('total amount spent = ' + str(total_amount))
-
-			utxos = self.taker.wallet.select_utxos(tx['srcmixdepth'], amount)
-			self.taker.start_cj(self.taker.wallet, amount, orders, utxos, destaddr,
-				changeaddr, self.taker.txfee, self.finishcallback)
+		self.sweep = sweep
+		self.balance = balance
+		self.tx = tx
+		self.destaddr = destaddr
+		self.create_tx()
 
 		self.lockcond.acquire()
 		self.lockcond.wait()
@@ -171,7 +197,7 @@ class TumblerThread(threading.Thread):
 		maker_count = sum([tx['makercount'] for tx in self.taker.tx_list])
 		debug('uses ' + str(maker_count) + ' makers, at ' + str(relorder_fee*100) + '% per maker, estimated total cost '
 			+ str(round((1 - (1 - relorder_fee)**maker_count) * 100, 3)) + '%')
-
+		debug('waiting for orders to arrive')
 		time.sleep(orderwaittime)
 		debug('starting')
 		self.lockcond = threading.Condition()
@@ -185,7 +211,7 @@ class TumblerThread(threading.Thread):
 				if later_tx['srcmixdepth'] == tx['srcmixdepth']:
 					sweep = False
 			self.current_tx = i
-			self.send_tx(tx, self.balance_by_mixdepth[tx['srcmixdepth']], sweep)
+			self.init_tx(tx, self.balance_by_mixdepth[tx['srcmixdepth']], sweep)
 
 		debug('total finished')
 		self.taker.msgchan.shutdown()


### PR DESCRIPTION
Implemented changes suggested in #166

A new thread is started for each CoinJoinTX object, there is a threading condition lock which passes notifications between the two threads. Currently the timeout for maker non-reply is 10 seconds.

If a maker doesn't reply, it will be ignored for the rest of lifetime of the Taker instance.

`sendpayment.py` and `tumbler.py` have been made to work with this.

Testing welcome. I've tested this on regtest with tumbler, it was able to complete it's run even though one maker never responded to either !fill, !auth or !tx