### PR TITLE
Crude recovery by taker from unresponsive makers

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -117,7 +117,7 @@ def rand_norm_array(mu, sigma, n):
 
 def rand_exp_array(lamda, n):
 	#'lambda' is reserved (in case you are triggered by spelling errors)
-	return [random.expovariate(lamda) for i in range(n)]
+	return [random.expovariate(1.0 / lamda) for i in range(n)]
 
 def rand_pow_array(power, n):
 	#rather crude in that uses a uniform sample which is a multiple of 1e-4

--- a/lib/irc.py
+++ b/lib/irc.py
@@ -156,9 +156,12 @@ class IRCMessageChannel(MessageChannel):
 	def __privmsg(self, nick, cmd, message):
 		debug('>>privmsg ' + 'nick=' + nick + ' cmd=' + cmd + ' msg=' + message)
 		#should we encrypt?
-		box = self.__get_encryption_box(cmd, nick)
+		box, encrypt = self.__get_encryption_box(cmd, nick)
 		#encrypt before chunking
-		if box:
+		if encrypt:
+			if not box:
+				debug('error, dont have encryption box object for ' + nick + ', dropping message')
+				return
 			message = enc_wrapper.encrypt_encode(message, box)
 
 		header = "PRIVMSG " + nick + " :"
@@ -302,9 +305,9 @@ class IRCMessageChannel(MessageChannel):
 		to check which command strings correspond to which
 		type of object (maker/taker).''' #old doc, dont trust
 		if cmd in plaintext_commands:
-			return None
+			return None, False
 		else:
-			return self.cjpeer.get_crypto_box_from_nick(nick)
+			return self.cjpeer.get_crypto_box_from_nick(nick), True
 
 	def __handle_privmsg(self, source, target, message):
 		nick = get_irc_nick(source)
@@ -330,15 +333,22 @@ class IRCMessageChannel(MessageChannel):
 				self.built_privmsg[nick] = [cmd_string, message[:-2]]
 			else:
 				self.built_privmsg[nick][1] += message[:-2]
-			box = self.__get_encryption_box(self.built_privmsg[nick][0], nick)
+			box, encrypt = self.__get_encryption_box(self.built_privmsg[nick][0], nick)
 			if message[-1]==';':
 				self.waiting[nick]=True
 			elif message[-1]=='~':
 				self.waiting[nick]=False
-				if box:
+				if encrypt:
+					if not box:
+						debug('error, dont have encryption box object for ' + nick + ', dropping message')
+						return
 					#need to decrypt everything after the command string
 					to_decrypt = ''.join(self.built_privmsg[nick][1].split(' ')[1])
-					decrypted = enc_wrapper.decode_decrypt(to_decrypt, box)
+					try:
+						decrypted = enc_wrapper.decode_decrypt(to_decrypt, box)
+					except ValueError as e:
+						debug('valueerror when decrypting, skipping: ' + repr(e))
+						return
 					parsed = self.built_privmsg[nick][1].split(' ')[0] + ' ' + decrypted
 				else:
 					parsed = self.built_privmsg[nick][1]

--- a/lib/taker.py
+++ b/lib/taker.py
@@ -353,7 +353,11 @@ class Taker(OrderbookWatch):
 		# that some other guy doesnt send you confusing stuff
 
 	def get_crypto_box_from_nick(self, nick):
-		return self.cjtx.crypto_boxes[nick][1] #libsodium encryption object
+		if nick in self.cjtx.crypto_boxes:
+			return self.cjtx.crypto_boxes[nick][1] #libsodium encryption object
+		else:
+			debug('something wrong, no crypto object, nick=' + nick + ', message will be dropped')
+			return None
 
 	def start_cj(self, wallet, cj_amount, orders, input_utxos, my_cj_addr, my_change_addr,
 			my_txfee, finishcallback=None, choose_orders_recover=None):

--- a/patientsendpayment.py
+++ b/patientsendpayment.py
@@ -34,7 +34,7 @@ class TakerThread(threading.Thread):
 		print 'giving up waiting'
 		#cancel the remaining order
 		self.tmaker.modify_orders([0], [])
-		orders, total_cj_fee = choose_order(self.tmaker.db, self.tmaker.amount, self.tmaker.makercount, weighted_order_choose)
+		orders, total_cj_fee = choose_orders(self.tmaker.db, self.tmaker.amount, self.tmaker.makercount, weighted_order_choose)
 		print 'chosen orders to fill ' + str(orders) + ' totalcjfee=' + str(total_cj_fee)
 		total_amount = self.tmaker.amount + total_cj_fee + self.tmaker.txfee
 		print 'total amount spent = ' + str(total_amount)

--- a/sendpayment.py
+++ b/sendpayment.py
@@ -12,7 +12,6 @@ from irc import IRCMessageChannel, random_nick
 import bitcoin as btc
 
 def check_high_fee(total_fee_pc):
-	debug('total coinjoin fee = ' + str(float('%.3g' % (100.0 * total_fee_pc))) + '%')
 	WARNING_THRESHOLD = 0.02 # 2%
 	if total_fee_pc > WARNING_THRESHOLD:
 		print '\n'.join(['='* 60]*3)
@@ -22,7 +21,6 @@ def check_high_fee(total_fee_pc):
 		print '\n'.join(['='* 60]*1)
 		print 'WARNING   ' * 6
 		print '\n'.join(['='* 60]*3)
-	
 
 #thread which does the buy-side algorithm
 # chooses which coinjoins to initiate and when
@@ -31,56 +29,87 @@ class PaymentThread(threading.Thread):
 		threading.Thread.__init__(self)
 		self.daemon = True
 		self.taker = taker
+		self.ignored_makers = []
 
-	def finishcallback(self, coinjointx):
-		self.taker.msgchan.shutdown()
-
-	def run(self):
-		print 'waiting for all orders to certainly arrive'
-		time.sleep(self.taker.waittime)
-
+	def create_tx(self):
 		crow = self.taker.db.execute('SELECT COUNT(DISTINCT counterparty) FROM orderbook;').fetchone()
 		counterparty_count = crow['COUNT(DISTINCT counterparty)']
+		counterparty_count -= len(self.ignored_makers)
 		if counterparty_count < self.taker.makercount:
 			print 'not enough counterparties to fill order, ending'
 			self.taker.msgchan.shutdown()
 			return
 
+		utxos = None
+		orders = None
+		cjamount = 0
+		change_addr = None
+		choose_orders_recover = None
 		if self.taker.amount == 0:
-			utxo_list = self.taker.wallet.get_utxos_by_mixdepth()[self.taker.mixdepth]
-			total_value = sum([va['value'] for va in utxo_list.values()])
-			
-			orders, cjamount = choose_sweep_order(self.taker.db, total_value, \
-				self.taker.txfee, self.taker.makercount, self.taker.chooseOrdersFunc)
+			utxos = self.taker.wallet.get_utxos_by_mixdepth()[self.taker.mixdepth]
+			total_value = sum([va['value'] for va in utxos.values()])
+			orders, cjamount = choose_sweep_orders(self.taker.db, total_value,
+				self.taker.txfee, self.taker.makercount,
+				self.taker.chooseOrdersFunc, self.ignored_makers)
 			if not self.taker.answeryes:
 				debug('total cj fee = ' + str(total_value - cjamount))
 				total_fee_pc = 1.0*(total_value - cjamount) / cjamount
+				debug('total coinjoin fee = ' + str(float('%.3g' % (100.0 * total_fee_pc))) + '%')
 				check_high_fee(total_fee_pc)
 				if raw_input('send with these orders? (y/n):')[0] != 'y':
 					self.finishcallback(None)
 					return
-			self.taker.start_cj(self.taker.wallet, cjamount, orders, utxo_list,
-				self.taker.destaddr, None, self.taker.txfee, self.finishcallback)
 		else:
-			orders, total_cj_fee = choose_order(self.taker.db, self.taker.amount, \
-				self.taker.makercount, self.taker.chooseOrdersFunc)
+			orders, total_cj_fee = self.sendpayment_choose_orders(self.taker.amount,
+				self.taker.makercount)
 			if not orders:
 				debug('ERROR not enough liquidity in the orderbook, exiting')
 				return
-			print 'chosen orders to fill ' + str(orders) + ' totalcjfee=' + str(total_cj_fee)
-			if not self.taker.answeryes:
-				total_fee_pc = 1.0*total_cj_fee / self.taker.amount
-				check_high_fee(total_fee_pc)
-				if raw_input('send with these orders? (y/n):')[0] != 'y':
-					self.finishcallback(None)
-					return
 			total_amount = self.taker.amount + total_cj_fee + self.taker.txfee
 			print 'total amount spent = ' + str(total_amount)
-
 			utxos = self.taker.wallet.select_utxos(self.taker.mixdepth, total_amount)
-			self.taker.start_cj(self.taker.wallet, self.taker.amount, orders, utxos, self.taker.destaddr,
-				self.taker.wallet.get_change_addr(self.taker.mixdepth), self.taker.txfee,
-				self.finishcallback)
+			cjamount = self.taker.amount
+			change_addr = self.taker.wallet.get_change_addr(self.taker.mixdepth)
+			choose_orders_recover = self.sendpayment_choose_orders
+
+		self.taker.start_cj(self.taker.wallet, cjamount, orders, utxos,
+			self.taker.destaddr, change_addr, self.taker.txfee,
+			self.finishcallback, choose_orders_recover)
+
+	def finishcallback(self, coinjointx):
+		if coinjointx.txid:
+			debug('created fully signed tx, ending')
+			self.taker.msgchan.shutdown()
+			return
+		self.ignored_makers += coinjointx.nonrespondants
+		debug('recreating the tx, ignored_makers=' + str(self.ignored_makers))
+		self.create_tx()
+
+	def sendpayment_choose_orders(self, cj_amount, makercount, nonrespondants=[], active_nicks=[]):
+		self.ignored_makers += nonrespondants
+		orders, total_cj_fee = choose_orders(self.taker.db, cj_amount, makercount,
+			self.taker.chooseOrdersFunc, self.ignored_makers + active_nicks)
+		if not orders:
+			return None, 0
+		print 'chosen orders to fill ' + str(orders) + ' totalcjfee=' + str(total_cj_fee)
+		if not self.taker.answeryes:
+			if len(self.ignored_makers) > 0:
+				noun = 'total'
+			else:
+				noun = 'additional'
+			total_fee_pc = 1.0*total_cj_fee / cj_amount
+			debug(noun + ' coinjoin fee = ' + str(float('%.3g' % (100.0 * total_fee_pc))) + '%')
+			check_high_fee(total_fee_pc)
+			if raw_input('send with these orders? (y/n):')[0] != 'y':
+				self.taker.msgchan.shutdown()
+				return
+		return orders, total_cj_fee
+
+	def run(self):
+		print 'waiting for all orders to certainly arrive'
+		time.sleep(self.taker.waittime)
+		self.create_tx()
+
 
 class SendPayment(takermodule.Taker):
 	def __init__(self, msgchan, wallet, destaddr, amount, makercount, txfee, waittime, mixdepth, answeryes, chooseOrdersFunc):
@@ -169,3 +198,4 @@ def main():
 if __name__ == "__main__":
 	main()
 	print('done')
+

--- a/tumbler.py
+++ b/tumbler.py
@@ -102,11 +102,12 @@ class TumblerThread(threading.Thread):
 		while True:
 			orders, total_cj_fee = choose_orders(self.taker.db, cj_amount,
 				makercount, weighted_order_choose, self.ignored_makers + active_nicks)
-			cj_fee = 1.0*total_cj_fee / makercount / cj_amount
-			debug('average fee = ' + str(cj_fee))
+			abs_cj_fee = 1.0*total_cj_fee / makercount
+			rel_cj_fee = abs_cj_fee / cj_amount
+			debug('rel/abs average fee = ' + str(rel_cj_fee) + ' / ' + str(abs_cj_fee))
 
-			if cj_fee > self.taker.maxcjfee:
-				debug('cj fee higher than maxcjfee at ' + str(cj_fee) + ', waiting 60 seconds')
+			if rel_cj_fee > self.taker.maxcjfee[0] and abs_cj_fee > self.taker.maxcjfee[1]:
+				debug('cj fee higher than maxcjfee, waiting 60 seconds')
 				time.sleep(60)
 				continue
 			if orders == None:
@@ -135,10 +136,11 @@ class TumblerThread(threading.Thread):
 					debug('waiting for liquidity 1min, hopefully more orders should come in')
 					time.sleep(60)
 					continue
-				cj_fee = 1.0*(total_value - cj_amount) / self.tx['makercount'] / cj_amount
-				debug('average fee = ' + str(cj_fee))
-				if cj_fee > self.taker.maxcjfee:
-					print 'cj fee higher than maxcjfee at ' + str(cj_fee) + ', waiting 60 seconds'
+				abs_cj_fee = 1.0*(total_value - cj_amount) / self.tx['makercount']
+				rel_cj_fee = abs_cj_fee / cj_amount
+				debug('rel/abs average fee = ' + str(rel_cj_fee) + ' / ' + str(abs_cj_fee))
+				if rel_cj_fee > self.taker.maxcjfee[0] and abs_cj_fee > self.taker.maxcjfee[1]:
+					debug('cj fee higher than maxcjfee, waiting 60 seconds')
 					time.sleep(60)
 					continue
 				break
@@ -253,8 +255,10 @@ def main():
 		help='mixing depth to spend from, default=0', default=0)
 	parser.add_option('-f', '--txfee', type='int', dest='txfee',
 		default=10000, help='miner fee contribution, in satoshis, default=10000')
-	parser.add_option('-x', '--maxcjfee', type='float', dest='maxcjfee',
-		default=0.01, help='maximum coinjoin fee the tumbler is willing to pay to a single market maker. default=0.01 (1%)')
+	parser.add_option('-x', '--maxcjfee', type='float', dest='maxcjfee', nargs=2,
+		default=(0.01, 10000), help='maximum coinjoin fee and bitcoin value the tumbler is '
+		'willing to pay to a single market maker. Both values need to be exceeded, so if '
+		'the fee is 30% but only 500satoshi is paid the tx will go ahead. default=0.01, 10000 (1%, 10000satoshi)')
 	parser.add_option('-a', '--addrask', type='int', dest='addrask',
 		default=2, help='How many more addresses to ask for in the terminal. Should '
 			'be similar to --txcountparams. default=2')
@@ -264,10 +268,10 @@ def main():
 		'with mean 3 and standard deveation 1.5 inclusive, default=3 1.5', default=(3, 1.5))
 	parser.add_option('-M', '--mixdepthcount', type='int', dest='mixdepthcount',
 		help='How many mixing depths to mix through', default=4)
-	parser.add_option('-c', '--txcountparams', type='float', nargs=2, dest='txcountparams', default=(5, 1),
+	parser.add_option('-c', '--txcountparams', type='float', nargs=2, dest='txcountparams', default=(4, 1),
 		help='The number of transactions to take coins from one mixing depth to the next, it is'
 		' randomly chosen following a normal distribution. Should be similar to --addrask. '
-		'This option controlls the parameters of that normal curve. (mean, standard deviation). default=(3, 1)')
+		'This option controlls the parameters of that normal curve. (mean, standard deviation). default=(4, 1)')
 	parser.add_option('--amountpower', type='float', dest='amountpower', default=100.0,
 		help='The output amounts follow a power law distribution, this is the power, default=100.0')
 	parser.add_option('-l', '--timelambda', type='float', dest='timelambda', default=20,

--- a/tumbler.py
+++ b/tumbler.py
@@ -75,6 +75,8 @@ class TumblerThread(threading.Thread):
 		threading.Thread.__init__(self)
 		self.daemon = True
 		self.taker = taker
+		self.ignored_makers = []
+		self.sweeping = False
 
 	def unconfirm_callback(self, txd, txid):
 		debug('that was %d tx out of %d' % (self.current_tx+1, len(self.taker.tx_list)))
@@ -86,11 +88,78 @@ class TumblerThread(threading.Thread):
 		self.lockcond.release()
 
 	def finishcallback(self, coinjointx):
-		common.bc_interface.add_tx_notify(coinjointx.latest_tx,
-			self.unconfirm_callback, self.confirm_callback, coinjointx.my_cj_addr)
-		self.taker.wallet.remove_old_utxos(coinjointx.latest_tx)
+		if coinjointx.txid:
+			common.bc_interface.add_tx_notify(coinjointx.latest_tx,
+				self.unconfirm_callback, self.confirm_callback, coinjointx.my_cj_addr)
+			self.taker.wallet.remove_old_utxos(coinjointx.latest_tx)
+		else:
+			self.ignored_makers += coinjointx.nonrespondants
+			debug('recreating the tx, ignored_makers=' + str(self.ignored_makers))
+			self.create_tx()
 
-	def send_tx(self, tx, balance, sweep):
+	def tumbler_choose_orders(self, cj_amount, makercount, nonrespondants=[], active_nicks=[]):
+		self.ignored_makers += nonrespondants
+		while True:
+			orders, total_cj_fee = choose_orders(self.taker.db, cj_amount,
+				makercount, weighted_order_choose, self.ignored_makers + active_nicks)
+			cj_fee = 1.0*total_cj_fee / makercount / cj_amount
+			debug('average fee = ' + str(cj_fee))
+
+			if cj_fee > self.taker.maxcjfee:
+				debug('cj fee higher than maxcjfee at ' + str(cj_fee) + ', waiting 60 seconds')
+				time.sleep(60)
+				continue
+			if orders == None:
+				debug('waiting for liquidity 1min, hopefully more orders should come in')
+				time.sleep(60)
+				continue
+			break
+		debug('chosen orders to fill ' + str(orders) + ' totalcjfee=' + str(total_cj_fee))
+		return orders, total_cj_fee
+
+	def create_tx(self):
+		utxos = None
+		orders = None
+		cj_amount = 0
+		change_addr = None
+		choose_orders_recover = None
+		if self.sweep:
+			debug('sweeping')
+			utxos = self.taker.wallet.get_utxos_by_mixdepth()[self.tx['srcmixdepth']]
+			total_value = sum([addrval['value'] for addrval in utxos.values()])
+			while True:
+				orders, cj_amount = choose_sweep_orders(self.taker.db, total_value,
+					self.taker.txfee, self.tx['makercount'], weighted_order_choose,
+					self.ignored_makers)
+				if orders == None:
+					debug('waiting for liquidity 1min, hopefully more orders should come in')
+					time.sleep(60)
+					continue
+				cj_fee = 1.0*(total_value - cjamount) / tx['makercount'] / cjamount
+				debug('average fee = ' + str(cj_fee))
+				if cj_fee > self.taker.maxcjfee:
+					print 'cj fee higher than maxcjfee at ' + str(cj_fee) + ', waiting 60 seconds'
+					time.sleep(60)
+					continue
+				break
+		else:
+			cj_amount = int(self.tx['amount_fraction'] * self.balance)
+			if cj_amount < self.taker.mincjamount:
+				debug('cj amount too low, bringing up')
+				cj_amount = self.taker.mincjamount
+			change_addr = self.taker.wallet.get_change_addr(self.tx['srcmixdepth'])
+			debug('coinjoining ' + str(cj_amount) + ' satoshi')
+			orders, total_cj_fee = self.tumbler_choose_orders(cj_amount, self.tx['makercount'])
+			total_amount = cj_amount + total_cj_fee + self.taker.txfee
+			debug('total amount spent = ' + str(total_amount))
+			utxos = self.taker.wallet.select_utxos(self.tx['srcmixdepth'], cj_amount)
+			choose_orders_recover = self.tumbler_choose_orders
+
+		self.taker.start_cj(self.taker.wallet, cj_amount, orders, utxos,
+			self.destaddr, change_addr, self.taker.txfee,
+			self.finishcallback, choose_orders_recover)
+
+	def init_tx(self, tx, balance, sweep):
 		destaddr = None
 		if tx['destination'] == 'internal':
 			destaddr = self.taker.wallet.get_receive_addr(tx['srcmixdepth'] + 1)
@@ -103,55 +172,11 @@ class TumblerThread(threading.Thread):
 				print 'Address ' + destaddr + ' invalid. ' + errormsg + ' try again'
 		else:
 			destaddr = tx['destination']
-
-		if sweep:
-			debug('sweeping')
-			all_utxos = self.taker.wallet.get_utxos_by_mixdepth()[tx['srcmixdepth']]
-			total_value = sum([addrval['value'] for addrval in all_utxos.values()])
-			while True:
-				orders, cjamount = choose_sweep_order(self.taker.db, total_value, self.taker.txfee, tx['makercount'], weighted_order_choose)
-				if orders == None:
-					debug('waiting for liquidity 1min, hopefully more orders should come in')
-					time.sleep(60)
-					continue
-				cj_fee = 1.0*(total_value - cjamount) / tx['makercount'] / cjamount
-				debug('average fee = ' + str(cj_fee))
-				if cj_fee > self.taker.maxcjfee:
-					print 'cj fee higher than maxcjfee at ' + str(cj_fee) + ', waiting 60 seconds'
-					time.sleep(60)
-					continue
-				break
-			self.taker.start_cj(self.taker.wallet, cjamount, orders, all_utxos, destaddr,
-				None, self.taker.txfee, self.finishcallback)
-		else:
-			amount = int(tx['amount_fraction'] * balance)
-			if amount < self.taker.mincjamount:
-				debug('cj amount too low, bringing up')
-				amount = self.taker.mincjamount
-			changeaddr = self.taker.wallet.get_change_addr(tx['srcmixdepth'])
-			debug('coinjoining ' + str(amount) + ' satoshi')
-			while True:
-				orders, total_cj_fee = choose_order(self.taker.db, amount, tx['makercount'], weighted_order_choose)
-				cj_fee = 1.0*total_cj_fee / tx['makercount'] / amount
-				debug('average fee = ' + str(cj_fee))
-
-				if cj_fee > self.taker.maxcjfee:
-					debug('cj fee higher than maxcjfee at ' + str(cj_fee) + ', waiting 60 seconds')
-					time.sleep(60)
-					continue
-				if orders == None:
-					debug('waiting for liquidity 1min, hopefully more orders should come in')
-					time.sleep(60)
-					continue
-				break
-			debug('chosen orders to fill ' + str(orders) + ' totalcjfee=' + str(total_cj_fee))
-			total_amount = amount + total_cj_fee + self.taker.txfee
-			debug('total amount spent = ' + str(total_amount))
-
-			utxos = self.taker.wallet.select_utxos(tx['srcmixdepth'], total_amount)
-			self.taker.start_cj(self.taker.wallet, amount, orders, utxos, destaddr,
-				changeaddr, self.taker.txfee, self.finishcallback)
-
+		self.sweep = sweep
+		self.balance = balance
+		self.tx = tx
+		self.destaddr = destaddr
+		self.create_tx()
 		self.lockcond.acquire()
 		self.lockcond.wait()
 		self.lockcond.release()
@@ -171,7 +196,7 @@ class TumblerThread(threading.Thread):
 		maker_count = sum([tx['makercount'] for tx in self.taker.tx_list])
 		debug('uses ' + str(maker_count) + ' makers, at ' + str(relorder_fee*100) + '% per maker, estimated total cost '
 			+ str(round((1 - (1 - relorder_fee)**maker_count) * 100, 3)) + '%')
-
+		debug('waiting for orders to arrive')
 		time.sleep(orderwaittime)
 		debug('starting')
 		self.lockcond = threading.Condition()
@@ -185,7 +210,7 @@ class TumblerThread(threading.Thread):
 				if later_tx['srcmixdepth'] == tx['srcmixdepth']:
 					sweep = False
 			self.current_tx = i
-			self.send_tx(tx, self.balance_by_mixdepth[tx['srcmixdepth']], sweep)
+			self.init_tx(tx, self.balance_by_mixdepth[tx['srcmixdepth']], sweep)
 
 		debug('total finished')
 		self.taker.msgchan.shutdown()
@@ -208,10 +233,13 @@ class Tumbler(takermodule.Taker):
 		self.maxcjfee = maxcjfee
 		self.txfee = txfee
 		self.mincjamount = mincjamount
+		self.tumbler_thread = None
 
 	def on_welcome(self):
 		takermodule.Taker.on_welcome(self)
-		TumblerThread(self).start()
+		if not self.tumbler_thread:
+			self.tumbler_thread = TumblerThread(self)
+			self.tumbler_thread.start()
 
 def main():
 	parser = OptionParser(usage='usage: %prog [options] [wallet file] [destaddr(s)...]',
@@ -328,6 +356,7 @@ def main():
 		debug('CRASHING, DUMPING EVERYTHING')
 		debug_dump_object(wallet, ['addr_cache', 'keys', 'seed'])
 		debug_dump_object(tumbler)
+		debug_dump_object(tumbler.cjtx)
 		import traceback
 		debug(traceback.format_exc())
 
@@ -335,3 +364,4 @@ def main():
 if __name__ == "__main__":
 	main()
 	print('done')
+

--- a/tumbler.py
+++ b/tumbler.py
@@ -152,7 +152,7 @@ class TumblerThread(threading.Thread):
 			orders, total_cj_fee = self.tumbler_choose_orders(cj_amount, self.tx['makercount'])
 			total_amount = cj_amount + total_cj_fee + self.taker.txfee
 			debug('total amount spent = ' + str(total_amount))
-			utxos = self.taker.wallet.select_utxos(self.tx['srcmixdepth'], cj_amount)
+			utxos = self.taker.wallet.select_utxos(self.tx['srcmixdepth'], total_amount)
 			choose_orders_recover = self.tumbler_choose_orders
 
 		self.taker.start_cj(self.taker.wallet, cj_amount, orders, utxos,

--- a/tumbler.py
+++ b/tumbler.py
@@ -135,7 +135,7 @@ class TumblerThread(threading.Thread):
 					debug('waiting for liquidity 1min, hopefully more orders should come in')
 					time.sleep(60)
 					continue
-				cj_fee = 1.0*(total_value - cjamount) / tx['makercount'] / cjamount
+				cj_fee = 1.0*(total_value - cj_amount) / self.tx['makercount'] / cj_amount
 				debug('average fee = ' + str(cj_fee))
 				if cj_fee > self.taker.maxcjfee:
 					print 'cj fee higher than maxcjfee at ' + str(cj_fee) + ', waiting 60 seconds'


### PR DESCRIPTION
Implemented changes suggested in #166

A new thread is started for each CoinJoinTX object, there is a threading condition lock which passes notifications between the two threads. Currently the timeout for maker non-reply is 10 seconds.

If a maker doesn't reply, it will be ignored for the rest of lifetime of the Taker instance.

`sendpayment.py` and `tumbler.py` have been made to work with this.

Testing welcome. I've tested this on regtest with tumbler, it was able to complete it's run even though one maker never responded to either !fill, !auth or !tx

Second attempt at merging, given the derping with the other branch.

Please test, especially let me know if you encounter an unresponsive maker. Watch if the taker handles that in the correct manner.