### PR TITLE
Fix graphs when no display environment defined.

### DIFF
--- a/ob-watcher.py
+++ b/ob-watcher.py
@@ -34,6 +34,8 @@ def calc_order_size_data(db):
 
 def create_depth_chart(db, cj_amount):
 	try:
+		import matplotlib
+                matplotlib.use('Agg')
 		import matplotlib.pyplot as plt
 	except ImportError:
 		return 'Install matplotlib to see graphs'
@@ -56,6 +58,8 @@ def create_depth_chart(db, cj_amount):
 
 def create_size_histogram(db, args):
 	try:
+		import matplotlib
+                matplotlib.use('Agg')
 		import matplotlib.pyplot as plt
 	except ImportError:
 		return 'Install matplotlib to see graphs'


### PR DESCRIPTION
I had the following error occur on my site watcher after setting up on new hardware:

    Exception happened during processing of request from (127.0.0.1, 41073)         
    Traceback (most recent call last):                                                
      File "/usr/lib/python2.7/SocketServer.py", line 295, in _handle_request_noblock 
        self.process_request(request, client_address)                                 
      File "/usr/lib/python2.7/SocketServer.py", line 321, in process_request         
        self.finish_request(request, client_address)                                  
      File "/usr/lib/python2.7/SocketServer.py", line 334, in finish_request          
        self.RequestHandlerClass(request, client_address, self)                       
      File "ob-watcher.py", line 105, in __init__                                     
        SimpleHTTPServer.SimpleHTTPRequestHandler.__init__(self, request, client_addre
    ss, base_server)                                                                  
      File "/usr/lib/python2.7/SocketServer.py", line 655, in __init__                
        self.handle()                                                                 
      File "/usr/lib/python2.7/BaseHTTPServer.py", line 340, in handle                
        self.handle_one_request()                                                     
      File "/usr/lib/python2.7/BaseHTTPServer.py", line 328, in handle_one_request    
        method()                                                                      
      File "ob-watcher.py", line 164, in do_GET                                       
        MAINBODY: create_size_histogram(self.taker.db, args)                        
      File "ob-watcher.py", line 59, in create_size_histogram                         
        fig = plt.figure()                                                            
      File "/usr/lib/python2.7/dist-packages/matplotlib/pyplot.py", line 435, in figure                                                                                 
        **kwargs)                                                                     
      File "/usr/lib/python2.7/dist-packages/matplotlib/backends/backend_tkagg.py", line 81, in new_figure_manager                                                      
        return new_figure_manager_given_figure(num, figure)                           
      File "/usr/lib/python2.7/dist-packages/matplotlib/backends/backend_tkagg.py", line 89, in new_figure_manager_given_figure                                         
        window = Tk.Tk()                                                              
      File "/usr/lib/python2.7/lib-tk/Tkinter.py", line 1813, in __init__             
        self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)                                                          
    TclError: no display name and no $DISPLAY environment variable

From some research I found [this.](https://stackoverflow.com/questions/2801882/generating-a-png-with-matplotlib-when-display-is-undefined) I have done some more research [here](http://matplotlib.org/faq/usage_faq.html#what-is-a-backend), and it seems the fix suggested on stackoverflow should be safe. Please tell me if this is not good to have included for some reason (maybe break some os or something, too unique of a scenario, etc).

Another solution is for the user to set this independently in matplotlibrc, so maybe that is better. Well I offer the pr in case it is good to have.