### PR TITLE
consider only 1 order from each counterparty before choosing

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -532,7 +532,14 @@ def choose_orders(db, cj_amount, n, chooseOrdersBy, ignored_makers=[]):
 		debug('ERROR not enough liquidity in the orderbook n=%d suitable-counterparties=%d amount=%d totalorders=%d'
 			% (n, len(counterparties), cj_amount, len(orders)))
 		return None, 0 #TODO handle not enough liquidity better, maybe an Exception
-	orders = sorted(orders, key=lambda k: k[2]) #sort from smallest to biggest cj fee
+	#restrict to one order per counterparty, choose the one with the lowest cjfee
+	#this is done in advance of the order selection algo, so applies to all of them.
+	#however, if orders are picked manually, allow duplicates.
+	if chooseOrdersBy != pick_order:
+		orders = dict((v[0],v) for v in sorted(orders, key=lambda k: k[2], reverse=True)).values()
+	else:
+		orders = sorted(orders, key=lambda k: k[2]) #sort from smallest to biggest cj fee	
+
 	debug('considered orders = \n' + '\n'.join([str(o) for o in orders]))
 	total_cj_fee = 0
 	chosen_orders = []


### PR DESCRIPTION
I spent some time thinking about the right way to handle the issue in #197.

From one angle it looks like a very small problem that's being solved here, because the code already enforces one order being accepted from each counterparty. But as noted, the probabilities are skewed in case the choice algorithm chosen is probabilistic, because the weighting is done before that enforcement. This code uses a Python one liner to take only one order from each counterparty - the one with the lowest calculated coinjoin fee - from each counterparty before doing any selection algorithm. I put an if/else in case someone wants to make a manual choice.

(Btw in case you're wondering, reverse=True *is* correct here - the reason is a bit obscure).

I've done some test runs on a modified branch using new_yieldgen style yieldgen bots, further modified to artificially create multiple orders per mixdepth. I'm pretty sure it's functionally correct.

However, I can well imagine there may be further discussion about the *right* way to do this. Right now, I believe this would be a meaningful improvement since there are already bots running in the pit that duplicate orders over the same amount range.

 And of course it doesn't address the deeper problem discussed in #197.