### PR TITLE
fix of the fix of the fix of the counterparty selection

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -542,7 +542,7 @@ def choose_orders(db, cj_amount, n, chooseOrdersBy, ignored_makers=[]):
 	#this is done in advance of the order selection algo, so applies to all of them.
 	#however, if orders are picked manually, allow duplicates.
 	if chooseOrdersBy != pick_order:
-		orders = sorted(dict((v[0],v) for v in orders).values(), key=feekey)
+		orders = sorted(dict((v[0],v) for v in sorted(orders, key=feekey, reverse=True)).values(), key=feekey)
 	else:
 		orders = sorted(orders, key=feekey) #sort from smallest to biggest cj fee	
 


### PR DESCRIPTION
As per IRC. I did some runs with regtest, and *this* time I checked properly: it is taking one offer within range, and only the best offer, and the output is sorted by price. Previously I had stupidly only checked that it was taking one offer from each, ignoring the order.