### PR TITLE
Delete unused code: irc_privmsg_size_throttle()

### DIFF
--- a/lib/irc.py
+++ b/lib/irc.py
@@ -515,14 +515,3 @@ class IRCMessageChannel(MessageChannel):
 				time.sleep(30)
 		debug('ending irc')
 		self.give_up = True
-
-def irc_privmsg_size_throttle(irc, target, lines, prefix=''):
-	line = ''
-	for l in lines:
-		line += l
-		if len(line) > MAX_PRIVMSG_LEN:
-			irc.privmsg(target, prefix + line)
-			line = ''
-	if len(line) > 0:
-		irc.privmsg(target, prefix + line)
-


### PR DESCRIPTION
This functionality is [coded](https://github.com/chris-belcher/joinmarket/blob/master/lib/irc.py#L168-L178) [twice](https://github.com/chris-belcher/joinmarket/blob/master/lib/irc.py#L128-L132), but it's done differently in each and this leftover code only serves to confuse.